### PR TITLE
Fix broken unit synthesis for legacy mods.

### DIFF
--- a/TrainworksModdingTools/Legacy/Builders/CharacterBuilders/CharacterDataBuilder.cs
+++ b/TrainworksModdingTools/Legacy/Builders/CharacterBuilders/CharacterDataBuilder.cs
@@ -222,10 +222,10 @@ namespace Trainworks.Builders
             else
             {
                 UnitSynthesis = UnitSynthesisBuilder.Build();
+                CustomCharacterManager.RegisterUnitSynthesis(characterData, UnitSynthesis);
             }
 
-            CustomCharacterManager.RegisterCustomCharacter(characterData);
-            CustomCharacterManager.RegisterUnitSynthesis(characterData, UnitSynthesis);
+            CustomCharacterManager.RegisterCustomCharacter(characterData);            
 
             return characterData;
         }

--- a/TrainworksModdingTools/Managers/CustomCharacterManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCharacterManager.cs
@@ -134,13 +134,44 @@ namespace Trainworks.Managers
             UnitSynthesisMapping.Add(characterData, cardUpgrade);
         }
 
+        /// <summary> Gets unit synthesis for a custom character. </summary>
+        /// <param name="characterData"> Custom character data. </param>
+        /// <returns> The unit synthesis if this is a custom character, null otherwise. </returns>
+
         public static CardUpgradeData GetUnitSynthesis(CharacterData characterData)
         {
+            var cardUpgrades = ProviderManager.SaveManager.GetAllGameData().GetAllCardUpgradeData();
+
+            if (!CustomCharacterData.ContainsKey(characterData.GetID()))
+            {
+                //Trainworks.Log("Not a custom character " + characterData);
+                return null;
+            }
+
+            //Trainworks.Log("" + characterData);
+            // New Builders should already have this cached.
             if (UnitSynthesisMapping.TryGetValue(characterData, out CardUpgradeData value))
             {
+                //Trainworks.Log("Synthesis found for unit " + characterData + " " + value);
                 return value;
             }
-            return null;
+            // Legacy Builders need to find and cache the synthesis.
+            // Search in reverse as its most likely at the end ignoring dummy synthesis data if found.
+            else
+            {
+                var synthesis = cardUpgrades.FindLast(u => characterData == u.GetSourceSynthesisUnit() && u.GetUpgradeDescriptionKey() != "Default_dummy_synthesis_description");
+                if (synthesis != null)
+                {
+                    UnitSynthesisMapping.Add(characterData, synthesis);
+                    //Trainworks.Log("Synthesis found for unit " + characterData + " " + synthesis);
+                    return synthesis;
+                }
+            }
+            
+            //Trainworks.Log("No synthesis found for unit " + characterData);
+
+            // Last attempt find the dummy unit synthesis.
+            return cardUpgrades.FindLast(u => characterData == u.GetSourceSynthesisUnit());
         }
     }
 }


### PR DESCRIPTION
1) In legacy mods if the UnitSynthesis property of CharacterDataBuilder is used, then register it. 2) When looking up synthesis data, prioritize nondummy synthesis first when searching. 3) Otherwise, return the dummy synthesis if it exists.