### PR TITLE
Invisible unit bugfix, Visible unit bugfix, and Clan Selection Screen improvements.

### DIFF
--- a/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
@@ -29,7 +29,7 @@ namespace Trainworks.AssetConstructors
             // Create a new card GameObject from scratch
             // Cards are simple enough that we can get away with doing this
             GameObject cardGameObject = new GameObject();
-            cardGameObject.name = assetRef.RuntimeKey.ToString();
+            cardGameObject.name = "Card_" + sprite.name;
             Image newImage = cardGameObject.AddComponent<Image>();
             newImage.sprite = sprite;
 

--- a/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
@@ -50,12 +50,16 @@ namespace Trainworks.AssetConstructors
         /// <returns>The GameObject for the character</returns>
         private static GameObject CreateCharacterGameObject(AssetReference assetRef, Sprite sprite)
         {
+            // TODO this code is fishy... Shouldn't the Character be drawn using the MeshRenderer?
+
             // Create a new character GameObject by cloning an existing, working character
-            var characterGameObject = GameObject.Instantiate(CustomCharacterManager.TemplateCharacter);
+            // Moving the created game object to be LOUDER if something goes wrong.
+            var characterGameObject = GameObject.Instantiate(CustomCharacterManager.TemplateCharacter, new Vector3(5, 5, 0), new Quaternion());
 
             // Set aside its CharacterState and CharacterUI components for later use
             var characterState = characterGameObject.GetComponentInChildren<CharacterState>();
             var characterUI = characterGameObject.GetComponentInChildren<CharacterUI>();
+            var characterUIMesh = characterGameObject.GetComponentInChildren<CharacterUIMesh>(true);
 
             // Set the name, and hide the UI
             characterUI.HideDetails();
@@ -75,6 +79,13 @@ namespace Trainworks.AssetConstructors
             // Set states in the CharacterState and CharacterUI to the sprite to show it ingame
             AccessTools.Field(typeof(CharacterState), "sprite").SetValue(characterState, sprite);
             characterUI.GetSpriteRenderer().sprite = sprite;
+
+            // Disable the meshRenderer otherwise the templateCharacter will be displayed.
+            characterUIMesh.meshRenderer.forceRenderingOff = true;
+            characterUIMesh.meshRenderer.material = null;
+            characterUIMesh.meshRenderer.sharedMaterial = null;
+            characterUIMesh.meshRenderer.materials = Array.Empty<Material>();
+            characterUIMesh.meshRenderer.sharedMaterials = Array.Empty<Material>();
 
             // Set up the outline Sprite - well, seems like there will be problems here
             var outlineMesh = characterGameObject.GetComponentInChildren<CharacterUIOutlineMesh>(true);

--- a/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
@@ -17,6 +17,11 @@ namespace Trainworks.AssetConstructors
 {
     public class CharacterAssetConstructor : Interfaces.IAssetConstructor
     {
+        // Empty material used for static images for characters.
+        // Can't set to null directly or will get a ton of nasty warning messages each time its rendered.
+        // Can't disable the meshrenderer because its involved in rendering the characters.
+        public static Material NullMaterial = new Material(Shader.Find("Shiny Shoe/Character Spine Shader"));
+
         public GameObject Construct(AssetReference assetRef)
         {
             return CreateCharacterGameObject(assetRef);
@@ -115,10 +120,10 @@ namespace Trainworks.AssetConstructors
 
             // Disable the meshRenderer otherwise the templateCharacter will be displayed.
             characterUIMesh.meshRenderer.forceRenderingOff = true;
-            characterUIMesh.meshRenderer.material = null;
-            characterUIMesh.meshRenderer.sharedMaterial = null;
-            characterUIMesh.meshRenderer.materials = Array.Empty<Material>();
-            characterUIMesh.meshRenderer.sharedMaterials = Array.Empty<Material>();
+            characterUIMesh.meshRenderer.material = NullMaterial; 
+            characterUIMesh.meshRenderer.sharedMaterial = NullMaterial;
+            characterUIMesh.meshRenderer.materials = new Material[] { NullMaterial };
+            characterUIMesh.meshRenderer.sharedMaterials = new Material[] { NullMaterial };
 
             // Set up the outline Sprite - well, seems like there will be problems here
             var outlineMesh = characterGameObject.GetComponentInChildren<CharacterUIOutlineMesh>(true);

--- a/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
@@ -50,30 +50,6 @@ namespace Trainworks.AssetConstructors
         /// <returns>The GameObject for the character</returns>
         private static GameObject CreateCharacterGameObject(AssetReference assetRef, Sprite sprite)
         {
-            /*
-            // This code attempts to construct a Spine Object with no animations to match the imported PNG file. This gives us better outlining, draw order, and highlighting.
-
-            GameObject skeletonData = new GameObject();
-            skeletonData.name = sprite.name;
-            var s = skeletonData.AddComponent<SkeletonAnimation>();
-
-            // All we need is a complete and valid SkeletonDataAsset... does that include the atlas primarymaterial, atlas data, skeletonjson, state, and skeleton?
-            s.skeletonDataAsset = new SkeletonDataAsset();
-            s.skeletonDataAsset.skeletonJSON = new TextAsset("{\"skeleton\":{\"spine\":\"3.6.0.7-beta\",\"width\":" + sprite.rect.width + ",\"height\":" + sprite.rect.height + ",\"fps\":24,\"hash\":\" \",\"name\":\"Armature\"},\"bones\":[{\"name\":\"root\"}],\"slots\":[{\"name\":\"Unit\",\"bone\":\"root\",\"attachment\":\"Unit\"}],\"skins\":{\"default\":{\"Unit\":{\"Unit\":{\"name\":\"Unit\",\"width\":" + sprite.rect.width + ",\"height\":" + sprite.rect.height + ",\"y\":" + sprite.rect.width + "}}}}}");
-            s.skeletonDataAsset.atlasAssets.AddToArray<AtlasAssetBase>(new SpineAtlasAsset());
-            s.skeletonDataAsset.atlasAssets[0].
-            */
-
-            /*
-            Trainworks.Log(BepInEx.Logging.LogLevel.All, "We're doing the code!");
-            var skeletonData = TrainworksBundle.LoadAsset("assets/PNGTemplate.prefab") as GameObject;
-
-            return CreateCharacterGameObject(assetRef, sprite, skeletonData);
-
-
-            Trainworks.Log(BepInEx.Logging.LogLevel.All, "Character Template: " + CustomCharacterManager.TemplateCharacter);
-            */
-
             // Create a new character GameObject by cloning an existing, working character
             var characterGameObject = GameObject.Instantiate(CustomCharacterManager.TemplateCharacter);
 
@@ -97,15 +73,12 @@ namespace Trainworks.AssetConstructors
             spine.gameObject.SetActive(false);
 
             // Set states in the CharacterState and CharacterUI to the sprite to show it ingame
-            Traverse.Create(characterState).Field<Sprite>("sprite").Value = sprite;
+            AccessTools.Field(typeof(CharacterState), "sprite").SetValue(characterState, sprite);
             characterUI.GetSpriteRenderer().sprite = sprite;
 
             // Set up the outline Sprite - well, seems like there will be problems here
             var outlineMesh = characterGameObject.GetComponentInChildren<CharacterUIOutlineMesh>(true);
-            //Traverse.Create(outlineMesh).Field("outlineData").Field<Texture2D>("characterTexture").Value = sprite.texture;
-            //Traverse.Create(outlineMesh).Field("outlineData").Field<Texture2D>("outlineTexture").Value = sprite.texture;
-            Traverse.Create(outlineMesh).Field<CharacterOutlineData>("outlineData").Value = null; //CharacterOutlineData.Create(sprite.texture);
-            //Traverse.Create(outlineMesh).Field("outlineData").Field<Texture2D>("outlineTexture").Value = sprite.texture;
+            AccessTools.Field(typeof(CharacterUIOutlineMesh), "outlineData").SetValue(outlineMesh, null);
 
             return characterGameObject;
         }
@@ -164,8 +137,8 @@ namespace Trainworks.AssetConstructors
             GameObject.Destroy(spineMeshes.transform.GetChild(1).gameObject);
             GameObject.Destroy(spineMeshes.transform.GetChild(2).gameObject);
 
-            // Set googly eye positions
-            // Add in visual effects such as particles
+            // TODO Set googly eye positions
+            // TODO Add in visual effects such as particles
 
             // Remove our friends
             characterUI.GetComponent<SpriteRenderer>().forceRenderingOff = true;

--- a/TrainworksModdingTools/BuildersV2/ClassDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/ClassDataBuilder.cs
@@ -162,13 +162,17 @@ namespace Trainworks.BuildersV2
         /// </summary>}
         public string SubclassDescriptionLoc { get; set; }
         /// <summary>
-        /// Unused currently. Sets the Character ID to display in the Clan Select Screen
+        /// Sets the Character ID to display in the Clan Select Screen
         /// when the clan is selected as main.
+        /// Optimally you should create a new CharacterData with an upscaled model of your champion.
+        /// Otherwise it will appear tiny. The base game does this with separate versions of the CharacterData
+        /// used for the Clan Select Screen.
         /// </summary>
         public string[] ClassSelectScreenCharacterIDsMain { get; set; }
         /// <summary>
-        /// Unused currently. Sets the Character ID to display in the Clan Select Screen
+        /// Sets the Character ID to display in the Clan Select Screen
         /// when the clan is selected as secondary.
+        /// This could be set to any normal unit of your clan.
         /// </summary>
         public string[] ClassSelectScreenCharacterIDsSub { get; set; }
 

--- a/TrainworksModdingTools/Managers/CustomCharacterManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCharacterManager.cs
@@ -110,7 +110,6 @@ namespace Trainworks.Managers
         public static void LoadTemplateCharacter(SaveManager saveManager)
         {
             var characterData = saveManager.GetAllGameData().GetAllCharacterData()[0];
-            //var characterData = new CharacterData();
             var loadOperation = characterData.characterPrefabVariantRef.LoadAsset<GameObject>();
             loadOperation.Completed += TemplateCharacterLoadingComplete;
         }

--- a/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
+++ b/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
@@ -5,14 +5,22 @@ using HarmonyLib;
 using UnityEngine;
 using Trainworks.Managers;
 using BepInEx.Logging;
+using UnityEngine.AddressableAssets;
+using ShinyShoe;
+using Spine.Unity;
 
 namespace Trainworks.Patches
 {
-
-    // This patch displays custom characters on the clan select screen
+  // This patch displays custom characters on the clan select screen
     [HarmonyPatch(typeof(ClassSelectionScreen), "RefreshCharacters")]
     public class CustomClanSelectScreenPatch
     {
+        private static HashSet<String> ObjectsToRemove = new HashSet<String>
+        {
+            "HairFx", "LeftSymbolFx", "RightSymbolFx", // Sentient Extra Stuff.
+            "WyldentenGlow_RHand", "WyldentenGlow_LHand", "WyldentenGlow_Mask" // Wyldenten Extra Stuff.
+        };
+
         static void Prefix(ref bool __state, ref ClassSelectCharacterDisplay[] ___characterDisplays)
         {
             __state = false;
@@ -22,105 +30,256 @@ namespace Trainworks.Patches
             }
         }
 
-        static void Postfix(ref bool __state, ref ClassSelectCharacterDisplay[] ___characterDisplays, ref Transform ___charactersRoot)
+
+        
+        private static GameObject UpdateCharacterGameObject(CharacterState characterState, AssetReference assetRef)
         {
-            if (__state)
+            var runtimeKey = assetRef.RuntimeKey;
+            if (BundleManager.RuntimeKeyToBundleInfo.ContainsKey(runtimeKey))
             {
-                int customClassCount = CustomClassManager.CustomClassData.Values.Count;
-                int totalClassCount = ProviderManager.SaveManager.GetAllGameData().GetAllClassDatas().Count;
-                int vanillaClassCount = totalClassCount - customClassCount;
-                
-                // "totalClassCount + 1" to account for the random slot
-                var characterDisplaysNew = new ClassSelectCharacterDisplay[(totalClassCount + 1) * 2];
-
-                var characterDisplay = ___characterDisplays[0];
-
-                //Debug.Log("DISPLAYS LENGTH: " + ___characterDisplays.Length);
-                int i;
-                for (i = 0; i < ___characterDisplays.Length; i++)
+                var bundleInfo = BundleManager.RuntimeKeyToBundleInfo[runtimeKey];
+                var tex = BundleManager.LoadAssetFromBundle(bundleInfo, bundleInfo.SpriteName) as Texture2D;
+                if (tex == null)
                 {
-                    int clanIndex = (int)AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").GetValue(___characterDisplays[i]);
-                    if (clanIndex == vanillaClassCount + 1)
-                    { // Change index of random clan select display to account for custom classes
-                        AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(___characterDisplays[i], totalClassCount + 1);
-                        i++;
-                    }
-                    characterDisplaysNew[i] = ___characterDisplays[i];
+                    return null;
                 }
 
-                var customClasses = CustomClassManager.CustomClassData.Values;
-
-                int j = 0;
-                foreach (ClassData customClassData in customClasses)
+                Sprite sprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f), 128f);
+                sprite.name = "Sprite_" + bundleInfo.SpriteName.Replace("assets/", "").Replace(".png", "");
+                if (bundleInfo.ObjectName == null)
                 {
-                    // After vanilla clans, but before random slot
-                    // Note that each clan has two entries in __state, hence "(j / 2)"
-                    int clanIndex = vanillaClassCount + j + 1;
-
-                    var customMainCharacterDisplay = GameObject.Instantiate(characterDisplay);
-                    customMainCharacterDisplay.name = customClassData.name;
-                    characterDisplaysNew[clanIndex] = customMainCharacterDisplay;
-                    customMainCharacterDisplay.gameObject.SetActive(false);
-
-                    var customSubCharacterDisplay = GameObject.Instantiate(characterDisplay);
-                    customSubCharacterDisplay.name = customClassData.name + "sub";
-                    characterDisplaysNew[clanIndex + vanillaClassCount + 1] = customMainCharacterDisplay;
-                    customSubCharacterDisplay.gameObject.SetActive(false);
-
-                    //var mainCharacters = (List<CharacterState>)(AccessTools.Field(typeof(ClassSelectCharacterDisplay), "characters").GetValue(customMainCharacterDisplay));
-
-                    //CharacterState[] oldCharacterStates = customMainCharacterDisplay.GetComponentsInChildren<CharacterState>();
-
-                    //var oldCharacterState = oldCharacterStates[0];
-                    //var characterStateObject = oldCharacterState.gameObject;
-
-                    //var mainCharacterIDs = CustomClassManager.CustomClassSelectScreenCharacterIDsMain[customClassData.GetID()];
-                    //foreach (string mainCharacterID in mainCharacterIDs)
-                    //{
-                    //    var mainCharacterData = CustomCharacterManager.GetCharacterDataByID(mainCharacterID);
-                    //    var assetRef = mainCharacterData.characterPrefabVariantRef;
-
-                    //    var customStateObject = CustomAssetManager.LoadGameObjectFromAssetRef(assetRef);
-
-                    //    customStateObject.transform.parent = customMainCharacterDisplay.gameObject.transform;
-                    //}
-
-                    //AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(customMainCharacterDisplay, clanIndex);
-                    //customMainCharacterDisplay.name = customClassData.GetID() + "_Main";
-
-                    //foreach (CharacterState cs in oldCharacterStates)
-                    //{
-                    //    Debug.Log("DESTROY: " + cs.name);
-                    //    cs.transform.parent = null;
-                    //    GameObject.Destroy(cs);
-                    //}
-
-                    //oldCharacterStates = customMainCharacterDisplay.GetComponentsInChildren<CharacterState>();
-                    //foreach (CharacterState cs in oldCharacterStates)
-                    //{
-                    //    Debug.Log("CHARACTER STATE: " + cs.name);
-                    //}
-
-                    //    i++;
-
-                    //    var customSubCharacterDisplay = GameObject.Instantiate(characterDisplay);
-                    //    customSubCharacterDisplay.transform.parent = ___charactersRoot;
-                    //    customSubCharacterDisplay.gameObject.SetActive(false);
-                    //    characterDisplaysNew[i] = customSubCharacterDisplay;
-                    //    AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(customSubCharacterDisplay, clanIndex);
-                    //    customSubCharacterDisplay.name = customClassData.GetID() + "_Sub";
-
-                    j++;
+                    UpdateCharacterDisplayGameObject(characterState, sprite);
+                    return null;
                 }
 
-                ___characterDisplays = characterDisplaysNew;
+                GameObject gameObject = BundleManager.LoadAssetFromBundle(bundleInfo, bundleInfo.ObjectName) as GameObject;
+                if (gameObject == null)
+                {
+                    Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Could not find skeletonData for " + bundleInfo.ObjectName);
+                    UpdateCharacterDisplayGameObject(characterState, sprite);
+                    return null;
+                }
 
-                //Debug.Log("LENGTH: " + characterDisplaysNew.Length);
-                //for (int q = 0; q < characterDisplaysNew.Length; q++)
-                //{
-                //    Debug.Log("wow  " + characterDisplaysNew[q].name);
-                //}
+                gameObject = GameObject.Instantiate(gameObject);
+                UpdateCharacterDisplayGameObject(characterState, sprite, gameObject);
             }
+            else if (CustomAssetManager.RuntimeKeyToAssetInfo.ContainsKey(runtimeKey))
+            {
+                var sprite = CustomAssetManager.LoadSpriteFromRuntimeKey(runtimeKey);
+                UpdateCharacterDisplayGameObject(characterState, sprite);
+                return null;
+            }
+            return null;
+        }
+
+        private static void UpdateCharacterDisplayGameObject(CharacterState characterState, Sprite sprite)
+        {
+            // TODO this code is fishy... Shouldn't the Character be drawn using the MeshRenderer?
+            // Set aside its CharacterState and CharacterUI components for later use
+            var characterUI = characterState.GetComponentInChildren<CharacterUI>();
+            var characterUIMesh = characterState.GetComponentInChildren<CharacterUIMesh>(true);
+
+            // Set the name, and hide the UI
+            characterUI.HideDetails();
+            characterState.name = "Character_" + sprite.name + "_ClassSelect";
+
+            // Make its MeshRenderer active; this is what enables the sprite we're about to attach to show up
+            //characterState.GetComponentInChildren<MeshRenderer>(true).gameObject.SetActive(true);
+
+            // Delete all the spine anims
+            var spine = characterState.GetComponentInChildren<ShinyShoe.CharacterUIMeshSpine>(true);
+            foreach (Transform child in spine.transform)
+            {
+                GameObject.Destroy(child.gameObject);
+            }
+            spine.gameObject.SetActive(false);
+
+            // Set states in the CharacterState and CharacterUI to the sprite to show it ingame
+            AccessTools.Field(typeof(CharacterState), "sprite").SetValue(characterState, sprite);
+            characterUI.GetSpriteRenderer().sprite = sprite;
+            characterUI.GetSpriteRenderer().enabled = true;
+
+
+            // Disable the meshRenderer otherwise the templateCharacter will be displayed.
+            characterUIMesh.meshRenderer.forceRenderingOff = true;
+            characterUIMesh.meshRenderer.enabled = false;
+            characterUIMesh.meshRenderer.material = null;
+            characterUIMesh.meshRenderer.sharedMaterial = null;
+            characterUIMesh.meshRenderer.materials = Array.Empty<Material>();
+            characterUIMesh.meshRenderer.sharedMaterials = Array.Empty<Material>();
+
+            // Remove Extra GameObjects that are specific to cloned Champions.
+            // The Sentient's hair glow effects, and others really.
+            foreach (Transform c in characterUI.transform)
+            {
+                if (ObjectsToRemove.Contains(c.gameObject.name))
+                {
+                    GameObject.Destroy(c.gameObject);
+                }       
+            }
+
+            // Set up the outline Sprite - well, seems like there will be problems here
+            var outlineMesh = characterState.GetComponentInChildren<CharacterUIOutlineMesh>(true);
+            AccessTools.Field(typeof(CharacterUIOutlineMesh), "outlineData").SetValue(outlineMesh, null);
+
+            return;
+        }
+
+        private static void UpdateCharacterDisplayGameObject(CharacterState characterState, Sprite sprite, GameObject skeletonData)
+        {
+            // Set aside its CharacterState and CharacterUI components for later use
+            var characterUI = characterState.GetComponentInChildren<CharacterUI>();
+
+            // Hide the UI
+            characterState.gameObject.SetActive(true);
+            characterUI.HideDetails();
+            characterState.name = "Character_" + sprite.name + "_ClassSelect";
+
+            // Hide the quad, ensure the Spine mesh is shown (it should be by default)           
+            var Quad = characterState.GetComponentInChildren<ShinyShoe.CharacterUIMesh>(true).gameObject;
+            Quad.SetActive(false);
+
+            // Set the sprite for the preview
+            Traverse.Create(characterState).Field<Sprite>("sprite").Value = sprite;
+            characterUI.GetSpriteRenderer().sprite = sprite;
+            characterUI.GetSpriteRenderer().enabled = true;
+
+            // Set the shader
+            skeletonData.GetComponent<SkeletonAnimation>().addNormals = true;
+            skeletonData.GetComponent<SkeletonAnimation>().skeletonDataAsset.atlasAssets[0].PrimaryMaterial.shader = Shader.Find("Shiny Shoe/Character Spine Shader");
+
+            // Activate the SpineMesh
+            var spineMeshes = characterState.GetComponentInChildren<ShinyShoe.CharacterUIMeshSpine>(true);
+            spineMeshes.gameObject.SetActive(true);
+            //Bounds bounds;
+            //spineMeshes.Setup(sprite, true, 0f, characterGameObject.name, out bounds);
+
+            // Skeleton cloning produces superior effects
+            var clonedObject = characterState.GetComponentInChildren<SkeletonAnimation>().gameObject;
+            clonedObject.name = "Spine GameObject (" + characterState.name + ")";
+            clonedObject.SetActive(true);
+
+            var dest = clonedObject.GetComponentInChildren<SkeletonAnimation>();
+            var source = skeletonData.GetComponentInChildren<SkeletonAnimation>();
+
+
+            dest.skeletonDataAsset = source.skeletonDataAsset;
+            
+
+            // Destroy the evidence
+            GameObject.Destroy(skeletonData.gameObject);
+
+            // Now delete the pre-existing animations
+            GameObject.Destroy(spineMeshes.transform.GetChild(1).gameObject);
+            GameObject.Destroy(spineMeshes.transform.GetChild(2).gameObject);
+
+            // Remove Extra GameObjects that are specific to cloned Champions.
+            // The Sentient's hair glow effects, and others really.
+            foreach (Transform c in characterUI.transform)
+            {
+                if (ObjectsToRemove.Contains(c.gameObject.name))
+                {
+                    GameObject.Destroy(c.gameObject);
+                }
+            }
+
+            // TODO Set googly eye positions
+            // TODO Add in visual effects such as particles
+
+            // Remove our friends
+            characterUI.GetComponent<SpriteRenderer>().forceRenderingOff = true;
+            dest.gameObject.SetActive(false);
+
+            //Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Created spine component for " + characterGameObject.name);
+        }
+
+        static void Postfix(ref bool __state, ref ClassSelectCharacterDisplay[] ___characterDisplays, ClassSelectionIconUI ___mainClassSelectionUI,
+            ClassSelectionIconUI ___subClassSelectionUI, Transform ___charactersRoot, ClassSelectionScreen __instance)
+        {
+            if (!__state)
+                return;
+
+            int customClassCount = CustomClassManager.CustomClassData.Values.Count;
+            int totalClassCount = ProviderManager.SaveManager.GetAllGameData().GetAllClassDatas().Count;
+            int vanillaClassCount = totalClassCount - customClassCount;
+
+            // "totalClassCount + 1" to account for the random slot
+            var characterDisplaysNew = new ClassSelectCharacterDisplay[(totalClassCount + 1) * 2];
+
+            // Do not change. If this is changed then random effects will show up on the character
+            // Most champions have additional components for special effects which need to be removed.
+            // Awoken main (for some reason duplicating Hornbreaker Prince doesn't change the texture...).
+            var characterDisplayMain = ___characterDisplays[1];
+            // Awoken sub
+            var characterDisplaySub = ___characterDisplays[vanillaClassCount + 1 + 1];
+
+            // Setup is main classes then sub classes.
+            AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(___characterDisplays[vanillaClassCount], totalClassCount + 1);
+            AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(___characterDisplays[2 * vanillaClassCount + 1], totalClassCount + 1);
+
+            for (int i = 0; i < vanillaClassCount; i++)
+            {
+                characterDisplaysNew[i] = ___characterDisplays[i];
+                characterDisplaysNew[i + totalClassCount + 1] = ___characterDisplays[i + vanillaClassCount + 1];
+            }
+            characterDisplaysNew[totalClassCount] = ___characterDisplays[vanillaClassCount];
+            characterDisplaysNew[2 * totalClassCount + 1] = ___characterDisplays[2 * vanillaClassCount + 1];
+
+            int j = 0;
+            foreach (ClassData customClassData in CustomClassManager.CustomClassData.Values)
+            {
+                int clanIndex = vanillaClassCount + j;
+
+                var customMainCharacterDisplay = GameObject.Instantiate(characterDisplayMain, ___charactersRoot);
+                customMainCharacterDisplay.name = customClassData.name + " main";
+                characterDisplaysNew[clanIndex] = customMainCharacterDisplay;
+                AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(characterDisplaysNew[clanIndex], clanIndex + 1);
+
+                var customSubCharacterDisplay = GameObject.Instantiate(characterDisplaySub, ___charactersRoot);
+                customSubCharacterDisplay.name = customClassData.name + " sub";
+                characterDisplaysNew[clanIndex + totalClassCount + 1] = customSubCharacterDisplay;
+                AccessTools.Field(typeof(ClassSelectCharacterDisplay), "clanIndex").SetValue(characterDisplaysNew[clanIndex + totalClassCount + 1], clanIndex + 1);
+
+                var mainCharacterIDs = CustomClassManager.CustomClassSelectScreenCharacterIDsMain[customClassData.GetID()];
+                CharacterState[] characterStates = customMainCharacterDisplay.GetComponentsInChildren<CharacterState>(true);
+                for (int k = 0; k < characterStates.Length; k++)
+                {
+                    var characterState = characterStates[k];
+                    if (mainCharacterIDs == null || k >= mainCharacterIDs.Length)
+                    {
+                        characterState.gameObject.SetActive(false);
+                        continue;
+                    }
+                        
+                    var mainCharacterData = CustomCharacterManager.GetCharacterDataByID(mainCharacterIDs[k]);
+
+                    var assetRef = mainCharacterData.characterPrefabVariantRef;
+                    UpdateCharacterGameObject(characterState, assetRef);
+                    AccessTools.Field(typeof(ClassSelectCharacterDisplay), "characters").SetValue(customMainCharacterDisplay, null);
+                }
+
+                var subCharacterIDs = CustomClassManager.CustomClassSelectScreenCharacterIDsSub[customClassData.GetID()];
+                characterStates = customSubCharacterDisplay.GetComponentsInChildren<CharacterState>(true);
+                for (int k = 0; k < characterStates.Length; k++)
+                {
+                    var characterState = characterStates[k];
+                    if (subCharacterIDs == null || k >= subCharacterIDs.Length)
+                    {
+                        characterState.gameObject.SetActive(false);
+                        continue;
+                    }
+
+                    var subCharacterData = CustomCharacterManager.GetCharacterDataByID(subCharacterIDs[k]);
+
+                    var assetRef = subCharacterData.characterPrefabVariantRef;
+                    UpdateCharacterGameObject(characterState, assetRef);
+                    AccessTools.Field(typeof(ClassSelectCharacterDisplay), "characters").SetValue(customMainCharacterDisplay, null);
+                }
+
+                j++;
+            }
+
+            ___characterDisplays = characterDisplaysNew;
         }
     }
 }

--- a/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
+++ b/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
@@ -226,8 +226,7 @@ namespace Trainworks.Patches
             AccessTools.Field(typeof(CharacterUIOutlineMesh), "outlineData").SetValue(outlineMesh, null);
         }
 
-        static void Postfix(ref bool __state, ref ClassSelectCharacterDisplay[] ___characterDisplays, ClassSelectionIconUI ___mainClassSelectionUI,
-            ClassSelectionIconUI ___subClassSelectionUI, Transform ___charactersRoot, ClassSelectionScreen __instance)
+        static void Postfix(ref bool __state, ref ClassSelectCharacterDisplay[] ___characterDisplays, Transform ___charactersRoot)
         {
             if (!__state)
                 return;
@@ -286,7 +285,6 @@ namespace Trainworks.Patches
                     AccessTools.Field(typeof(ClassSelectCharacterDisplay), "characters").SetValue(customMainCharacterDisplay, null);
                 }
 
-
                 var subCharacterIDs = CustomClassManager.CustomClassSelectScreenCharacterIDsSub[customClassData.GetID()];
                 var customSubCharacterDisplay = GameObject.Instantiate(characterDisplaySub, ___charactersRoot);
                 customSubCharacterDisplay.name = customClassData.name + " sub";
@@ -308,7 +306,6 @@ namespace Trainworks.Patches
                     UpdateCharacterGameObject(characterState, assetRef);
                     AccessTools.Field(typeof(ClassSelectCharacterDisplay), "characters").SetValue(customSubCharacterDisplay, null);
                 }
-
 
                 j++;
             }


### PR DESCRIPTION
1.  Fix for https://github.com/KittenAqua/TrainworksModdingTools/issues/58

This was caused by not freeing up the created (static) character assets during a run. When you quit or leave a run all clan assets are unloaded; this unloading step was not done by Trainworks previously. I don't know the exact reason why these assets appear piled up on the Clan Select Screen, but destroying them all is what fixed it. On a new run, these assets will be recreated.

Performance is not an issue. Creating a character asset is not a performance-intensive operation.

1b. Also applied a fix for the Animated (Bundle) case. Fixing bundle loading, which destroyed the original assets upon loading, and you couldn't load twice. This bug showed up when reusing an asset for the Clan Selection Screen.

Animated sprites are no longer cached since they are destroyed like the static images when exiting a run. Again, the creation is not performance-intensive only taking a few milliseconds to complete

2. Fix for https://github.com/KittenAqua/TrainworksModdingTools/issues/57

This was caused by the MeshRenderer for static character assets not being changed correctly. The MeshRenderer still had the Alabaster_Guardian Material set, which apparently drew the Alabaster Guardian at (0,0), which is the bottom of the train.

Introduced a NullMaterial to stop renderering the character which fixed the issue.

3. New Feature Sprites for the Clan Selection Screen.

This completes the code for CustomClassSelectScreenCharacterDisplayPatch.cs, which was left unimplemented.
To use set ClassDataBuilder properties ClassSelectScreenCharacterIDsMain and ClassSelectScreenCharacterIDsSub

If not set, then nothing will display when the custom clan is selected.

4. Changed Asset name for Card Art.
Before this was the runtime key which is not friendly for debugging with the Unity Runtime Editor. Changed it to Card_<assetname>