### PR TITLE
Loose ends and version bump.

### DIFF
--- a/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
@@ -204,7 +204,7 @@ namespace Trainworks.BuildersV2
             {
                 Sprite sprite = CustomAssetManager.LoadSpriteFromPath(FullAssetPath);
                 AccessTools.Field(typeof(StatusEffectData), "icon").SetValue(statusEffect, sprite);
-                TMP_SpriteAssetUtils.AddTextIcon(FullAssetPath, sprite.name);
+                _ = TMP_SpriteAssetUtils.AddTextIcon(FullAssetPath, sprite.name);
             }
 
             StatusEffectManager manager = GameObject.FindObjectOfType<StatusEffectManager>() as StatusEffectManager;

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.1.1";
+        public const string VERSION = "2.2.0";
 
         /// <summary>
         /// The framework's logging source.

--- a/TrainworksModdingTools/Utilities/TMP_SpriteAssetUtils.cs
+++ b/TrainworksModdingTools/Utilities/TMP_SpriteAssetUtils.cs
@@ -27,6 +27,8 @@ namespace Trainworks.Utilities
         /// <summary>
         /// Add a custom text icon. The icon needs to be 24x24 exactly.
         /// If using BuildersV2.StatusEffectDataBuilder the status effect icon is added automatically.
+        /// 
+        /// To use add the html tag with name sprite and property name="iconname" within your card text or tooltip text.
         /// </summary>
         /// <param name="fullpath">Full path to the asset to add.</param>
         /// <param name="name">Optional name, if not given the filename is used. </param>
@@ -65,7 +67,11 @@ namespace Trainworks.Utilities
         /// </summary>
         internal static void Build()
         {
+            if (Icons.Count <= 0)
+                return;
+
             CustomSpriteAtlas = new Texture2D(MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE);
+
             Texture2D[] textures = Icons.Values.ToArray();
             Rect[] rects = CustomSpriteAtlas.PackTextures(Icons.Values.ToArray(), 0);
 


### PR DESCRIPTION
Don't build a TMP_SpriteAsset if there are no icons (nothing happens if you do I'd just rather it not do anything).

Visual Studio cleanup.