### PR TITLE
Performance improvements Version 1.

### DIFF
--- a/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
@@ -144,10 +144,14 @@ namespace Trainworks.BuildersV2
         /// </summary>
         public string BaseAssetPath { get; set; }
         /// <summary>
-        /// Path relative to the plugin's file path for the icon.
-        /// Note the icon should be a black and white image sized 24x24.
+        /// Path relative to the plugin's file path for the icon used in the Character Display UI.
         /// </summary>
         public string IconPath { get; set; }
+        /// <summary>
+        /// Path relative to the plugin's file path for the icon used for tooltips.
+        /// Note the icon should be a black and white image sized 24x24.
+        /// </summary>
+        public string TooltipIconPath { get; set; }
 
         public StatusEffectDataBuilder()
         {
@@ -204,7 +208,7 @@ namespace Trainworks.BuildersV2
             {
                 Sprite sprite = CustomAssetManager.LoadSpriteFromPath(FullAssetPath);
                 AccessTools.Field(typeof(StatusEffectData), "icon").SetValue(statusEffect, sprite);
-                _ = TMP_SpriteAssetUtils.AddTextIcon(FullAssetPath, sprite.name);
+                _ = TMP_SpriteAssetUtils.AddTextIcon(BaseAssetPath + "/" + TooltipIconPath, sprite.name);
             }
 
             StatusEffectManager manager = GameObject.FindObjectOfType<StatusEffectManager>() as StatusEffectManager;

--- a/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/StatusEffectDataBuilder.cs
@@ -150,6 +150,7 @@ namespace Trainworks.BuildersV2
         /// <summary>
         /// Path relative to the plugin's file path for the icon used for tooltips.
         /// Note the icon should be a black and white image sized 24x24.
+        /// This is optional if IconPath and TooltipIconPath are the same.
         /// </summary>
         public string TooltipIconPath { get; set; }
 
@@ -208,7 +209,14 @@ namespace Trainworks.BuildersV2
             {
                 Sprite sprite = CustomAssetManager.LoadSpriteFromPath(FullAssetPath);
                 AccessTools.Field(typeof(StatusEffectData), "icon").SetValue(statusEffect, sprite);
-                _ = TMP_SpriteAssetUtils.AddTextIcon(BaseAssetPath + "/" + TooltipIconPath, sprite.name);
+                if (sprite.texture.width == 24 && sprite.texture.height == 24 && TooltipIconPath == null)
+                {
+                    _ = TMP_SpriteAssetUtils.AddTextIcon(FullAssetPath, sprite.name);
+                }
+                else if (TooltipIconPath != null)
+                {
+                    _ = TMP_SpriteAssetUtils.AddTextIcon(BaseAssetPath + "/" + TooltipIconPath, sprite.name);
+                }
             }
 
             StatusEffectManager manager = GameObject.FindObjectOfType<StatusEffectManager>() as StatusEffectManager;

--- a/TrainworksModdingTools/Managers/ProviderManager.cs
+++ b/TrainworksModdingTools/Managers/ProviderManager.cs
@@ -73,7 +73,6 @@ namespace Trainworks.Managers
         public void NewProviderAvailable(IProvider newProvider)
         {
             ProviderDictionary[newProvider.GetType()] = (false, newProvider);
-            Trainworks.Log(BepInEx.Logging.LogLevel.Debug, newProvider.GetType().AssemblyQualifiedName + " Was Registered to ProviderManager");
         }
 
         /// <summary>

--- a/TrainworksModdingTools/Patches/InitializationPatches.cs
+++ b/TrainworksModdingTools/Patches/InitializationPatches.cs
@@ -6,6 +6,7 @@ using Trainworks.Managers;
 using Trainworks.Interfaces;
 using System.Linq;
 using Trainworks.Utilities;
+using ShinyShoe.Loading;
 
 namespace Trainworks.Patches
 {
@@ -15,7 +16,7 @@ namespace Trainworks.Patches
     [HarmonyPatch(typeof(SaveManager), "Initialize")]
     class SaveManagerInitializationPatch
     {
-        static void Postfix(SaveManager __instance)
+        public static void Postfix(SaveManager __instance)
         {
             CustomCharacterManager.LoadTemplateCharacter(__instance);
             CustomAssetManager.InitializeAssetConstructors();
@@ -29,7 +30,7 @@ namespace Trainworks.Patches
     [HarmonyPatch(typeof(AssetLoadingManager), "Start")]
     class AssetLoadingManagerInitializationPatch
     {
-        static void Postfix()
+        public static void Postfix()
         {
             List<IInitializable> initializables =
                 PluginManager.Plugins.Values.ToList()
@@ -37,8 +38,23 @@ namespace Trainworks.Patches
                     .Select((plugin) => (plugin as IInitializable))
                     .ToList();
             initializables.ForEach((initializable) => initializable.Initialize());
+        }
+    }
 
-            TMP_SpriteAssetUtils.Build();
+    [HarmonyPatch(typeof(LoadingScreen), "FadeOutFullScreen")]
+    class SpriteAssetInitializationPatch
+    {
+        private static bool HasBuiltSpriteAssets = false;
+        public static void Postfix()
+        {
+            // Here because not all clans Initialize via their Initialize.
+            // Note for later, Not everything is guaranteed to be loaded by clans.
+            // Not until the MainMenu screen is up.
+            if (!HasBuiltSpriteAssets)
+            {
+                TMP_SpriteAssetUtils.Build();
+                HasBuiltSpriteAssets = true;
+            }
         }
     }
 }

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.0";
+        public const string VERSION = "2.2.1";
 
         /// <summary>
         /// The framework's logging source.

--- a/TrainworksModdingTools/TrainworksModdingTools.csproj
+++ b/TrainworksModdingTools/TrainworksModdingTools.csproj
@@ -8,11 +8,10 @@
     <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutDir>..\..\..\..\workshop\content\1102190\TrainworksModdingTools\plugins</OutDir>
-    <DocumentationFile>C:\Program Files (x86)\Steam\steamapps\common\Monster Train\TrainworksModdingTools\TrainworksModdingTools.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\Program Files (x86)\Steam\steamapps\workshop\content\1102190\2205086946\plugins\TrainworksModdingTools.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
-    <OutputPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\1102190\TrainworksModdingTools\</OutputPath>
+    <OutDir>C:\Program Files (x86)\Steam\steamapps\workshop\content\1102190\2205086946\plugins</OutDir>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. Prevent mods from calling ImportCSV multiple times with the same data. The LocalizationManager library doesn't like this each call takes up to 1 second
2. Improve the performance of CustomLocalizationManager.ImportSingleLocalization previously made a 1 line CSV file called ImportCSV. This function was inefficient and is called multiple times for every Builder if mods chose not to make a CSV file. Now ImportSingleLocalization adds a single Term to the LanguageSource, taking 97% less time.
3. I added TooltipIconPath to StatusEffectDataBuilder. Some IconPaths given to this builder don't line up with the 24x24 size needed for the tooltip icon. It is not required if IconPath points to an image that is 24x24
4. Move the Sprite Asset to a better location so that it gets all of the Status Effect Icons.
5. Remove some spammy logs.

All mods come up in 30s after this pull request before it could theoretically take up to 900m