### PR TITLE
Add CustomLocalizationManager.AddReplacementString

### DIFF
--- a/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
+++ b/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
@@ -18,6 +18,8 @@ namespace Trainworks.Managers
     public class CustomLocalizationManager
     {
         private static readonly HashSet<String> CSVFilesLoaded = new HashSet<String>();
+        // Replacement strings currently in use
+        internal static Dictionary<string, ReplacementStringData> ReplacementStrings;
 
         // Required because the library just chokes. When we need plural support, we can reimplement this.
         // The existing issue was that LocalizationUtil.GetPluralsUsedByLanguages() returns one less than mTerm.Languages.Length
@@ -118,6 +120,27 @@ namespace Trainworks.Managers
                 ret += LocalizationManager.Sources[0].Export_CSV(Category);
             
             return ret;
+        }
+
+        /// <summary>
+        /// Adds a ReplacementString with key and replacement.
+        /// When used in tooltips and CardText will replace [keyword] with replacement.Localize().
+        /// </summary>
+        /// <param name="keyword"></param>
+        /// <param name="replacement">Localized text key for replacement</param>
+        /// <returns></returns>
+        public static bool AddReplacementString(string keyword, string replacement)
+        {
+            if (ReplacementStrings.ContainsKey(keyword))
+            {
+                Trainworks.Log("Attempt to add duplicate Replacement String Keyword: " + keyword);
+                return false;
+            }
+            ReplacementStringData replacementStringData = new ReplacementStringData();
+            AccessTools.Field(typeof(ReplacementStringData), "_keyword").SetValue(replacementStringData, keyword);
+            AccessTools.Field(typeof(ReplacementStringData), "_replacement").SetValue(replacementStringData, replacement);
+            ReplacementStrings.Add(keyword, replacementStringData);
+            return true;
         }
     }
 }

--- a/TrainworksModdingTools/Patches/InitializationPatches.cs
+++ b/TrainworksModdingTools/Patches/InitializationPatches.cs
@@ -32,10 +32,18 @@ namespace Trainworks.Patches
     {
         public static void Postfix()
         {
-            List<IInitializable> initializables =
+            // Initialize replacement string dict by grabbing a reference to LocalizationGlobalParameterHandle.
+            // Should be safe the object exists in memory at runtime as a static reference.
+            LanguageManager manager;
+            ProviderManager.TryGetProvider<LanguageManager>(out manager);
+            var handler = AccessTools.Field(typeof(LanguageManager), "_paramHandler").GetValue(manager);
+            var dict = AccessTools.Field(typeof(LocalizationGlobalParameterHandler), "_replacements").GetValue(handler);
+            CustomLocalizationManager.ReplacementStrings = (Dictionary<string, ReplacementStringData>)dict;
+
+            List <IInitializable> initializables =
                 PluginManager.Plugins.Values.ToList()
-                    .Where((plugin) => (plugin is IInitializable))
-                    .Select((plugin) => (plugin as IInitializable))
+                    .Where((plugin) => plugin is IInitializable)
+                    .Select((plugin) => plugin as IInitializable)
                     .ToList();
             initializables.ForEach((initializable) => initializable.Initialize());
         }


### PR DESCRIPTION
This is a nice thing to have when building CardText and TooltipText. Having to type <sprite name="xxx"> a billion times gets lame fast.