### PR TITLE
Fix for CardPull and Draft Rewards not respecting Card's unlock levels.

### DIFF
--- a/TrainworksModdingTools/Patches/AddCustomCardToPoolPatch.cs
+++ b/TrainworksModdingTools/Patches/AddCustomCardToPoolPatch.cs
@@ -7,6 +7,10 @@ using Trainworks.Managers;
 using System.Diagnostics;
 using System.Linq;
 
+// TODO Verify that these patches are sufficient.
+// Accessing a CardPool by indices will not work with these patches since the cards aren't actually added.
+// However implementing patches for random access will cause all Custom Cards to load at startup which
+// increases run startup time by 200% (+1.2 seconds).
 namespace Trainworks.Patches
 {
     /// <summary>
@@ -17,10 +21,11 @@ namespace Trainworks.Patches
     [HarmonyPatch(new Type[] { typeof(CardPool), typeof(ClassData), typeof(int), typeof(CollectableRarity), typeof(SaveManager), typeof(CardPoolHelper.RarityCondition), typeof(bool) })]
     class AddCustomCardToPoolPatch
     {
-        static void Postfix(ref List<CardData> __result, ref CardPool cardPool, ClassData classData, CollectableRarity paramRarity, CardPoolHelper.RarityCondition rarityCondition, bool testRarityCondition)
+        static void Postfix(ref List<CardData> __result, ref CardPool cardPool, ClassData classData, int classLevel, CollectableRarity paramRarity, CardPoolHelper.RarityCondition rarityCondition, bool testRarityCondition)
         {
             List<CardData> customCardsToAddToPool = CustomCardPoolManager.GetCardsForPoolSatisfyingConstraints(cardPool.name, classData, paramRarity, rarityCondition, testRarityCondition);
             __result.AddRange(customCardsToAddToPool);
+            __result.RemoveAll((CardData card) => card.GetUnlockLevel() > classLevel);
         }
     }
 

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.2";
+        public const string VERSION = "2.2.3";
 
         /// <summary>
         /// The framework's logging source.


### PR DESCRIPTION
Small fix, seems the author of the associated patch neglected the (int) parameter for classLevel.