### PR TITLE
Quick fix, Strings with ',' broke ImportSingleLocalization.

### DIFF
--- a/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
+++ b/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
@@ -80,6 +80,9 @@ namespace Trainworks.Managers
             if (string.IsNullOrEmpty(key)) return;
             if (!key.HasTranslation() && !CSVLineStrings.ContainsKey(key))
             {
+                if (!english.StartsWith("\"") && english.Contains(","))
+                    english = string.Format("\"{0}\"", english);
+
                 if (french == null) french = english;
                 if (german == null) german = english;
                 if (russian == null) russian = english;

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.3";
+        public const string VERSION = "2.2.4";
 
         /// <summary>
         /// The framework's logging source.


### PR DESCRIPTION
Escape strings that include ','

This was to make all of the inputs to CustomLocalizationManager follow a single csv format to shave off 1s of loadtime.