### PR TITLE
V2.2.6

### DIFF
--- a/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
@@ -63,6 +63,7 @@ namespace Trainworks.AssetConstructors
                 if (tex != null)
                 {
                     Sprite sprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f), 128f);
+                    sprite.name = tex.name;
                     return CreateCardGameObject(assetRef, sprite);
                 }
                 return null;

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.4";
+        public const string VERSION = "2.2.6";
 
         /// <summary>
         /// The framework's logging source.


### PR DESCRIPTION
Ensure that CardAssets's sprite name is filled out. Somehow caused Arcadian to wig out for some reason otherwise.