### PR TITLE
Fix the secondary clan's starter upgrade being ignored on Covenant 0.

### DIFF
--- a/TrainworksModdingTools/Patches/ClanStarterCardUpgradePatch.cs
+++ b/TrainworksModdingTools/Patches/ClanStarterCardUpgradePatch.cs
@@ -61,7 +61,7 @@ namespace Trainworks.Patches
                     }
 
                     // Handle the case where FullClanMod is installed ignore if the classes are the same.
-                    if (classData == classData2)
+                    if (classData != classData2)
                     {
                         cardUpgradeData = classData2.GetStarterCardUpgrade();
                         if (cardUpgradeData != null)


### PR DESCRIPTION
This was a bug introduced when handling the existence of the FullClan Mod. The conditional needed to be flipped. This is why if Vanilla/Wurmkin was selected the Infused upgrade wasn't applied. The code is correct for the Covenant 1 case.

Unfortunately the original method wasn't futureproofed since Wurmkin is the only clan that uses these fields. This led to the vanilla codebase only considering one of the Clans (preferring main) when applying the starter card upgrade the respective clans have. The method was rewritten to support custom clans with these fields set and consider and apply both ONLY if they aren't the same.