### PR TITLE
Bug fixes and Improvement to Custom Character Animations.

### DIFF
--- a/TrainworksModdingTools/BuildersV2/CharacterDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CharacterDataBuilder.cs
@@ -210,6 +210,14 @@ namespace Trainworks.BuildersV2
         /// Defautls to only attacking during Relentless.
         /// </summary>
         public BossState.AttackPhase ValidBossAttackPhase { get; set; }
+        /// <summary>
+        /// [Unused] Googly Eye Offsets.
+        /// </summary>
+        public Vector3 GooglyEyeOffsets { get; set; }
+        /// <summary>
+        /// [Unused] Googly Eye Spacing.
+        /// </summary>
+        public float GooglyEyeSpacing { get; set; }
 
         public CharacterDataBuilder()
         {
@@ -237,6 +245,8 @@ namespace Trainworks.BuildersV2
             CharacterChatterDataBuilder = new CharacterChatterDataBuilder();
             BypassPactCrystalsUpgradeDataList = new CharacterData.ReorderableCharacterShardUpgradeList();
             BypassPactCrystalsUpgradeDataBuilders = new List<CharacterShardUpgradeDataBuilder>();
+            GooglyEyeOffsets = Vector3.zero;
+            GooglyEyeSpacing = 0.7f;
 
             var assembly = Assembly.GetCallingAssembly();
             BaseAssetPath = PluginManager.PluginGUIDToPath[PluginManager.AssemblyNameToPluginGUID[assembly.FullName]];
@@ -251,6 +261,7 @@ namespace Trainworks.BuildersV2
         {
             var characterData = Build();
             CustomCharacterManager.RegisterCustomCharacter(characterData);
+            CustomCharacterManager.SetGooglyEyesOffset(characterData.GetID(), GooglyEyeOffsets);
 
             if (!characterData.IsChampion())
             {

--- a/TrainworksModdingTools/Managers/CustomCharacterManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCharacterManager.cs
@@ -37,6 +37,10 @@ namespace Trainworks.Managers
         /// Maps RoomModifierClassName to the custom sprite.
         /// </summary>
         public static IDictionary<string, Sprite> CustomRoomModifierIcons = new Dictionary<string, Sprite>();
+        /// <summary>
+        /// Googly Eye Offsets per character.
+        /// </summary>
+        public static IDictionary<string, Vector3> GooglyEyeOffsets = new Dictionary<string, Vector3>();
 
 
         /// <summary>
@@ -275,6 +279,38 @@ namespace Trainworks.Managers
             {
                 _ = TMP_SpriteAssetUtils.AddTextIcon(base_path + "/" + tooltip_icon_path, sprite.name);
             }
+        }
+
+        public static bool IsCustomCharacter(CharacterState characterState)
+        {
+            if (characterState == null) return false;
+            return IsCustomCharacter(characterState.GetSourceCharacterData());
+        }
+
+        public static bool IsCustomCharacter(CharacterData characterData)
+        {
+            if (characterData == null) return false;
+            return CustomCharacterData.ContainsKey(characterData.GetID());
+        }
+
+        public static Vector3 GetGooglyEyesOffset(CharacterState characterState)
+        {
+            if (characterState == null) return Vector3.zero;
+            return GetGooglyEyesOffset(characterState.GetSourceCharacterData());
+        }
+
+        public static Vector3 GetGooglyEyesOffset(CharacterData characterData)
+        {
+            if (characterData != null && GooglyEyeOffsets.ContainsKey(characterData.GetID()))
+            {
+                return GooglyEyeOffsets[characterData.GetID()];
+            }
+            return Vector3.zero;
+        }
+
+        public static void SetGooglyEyesOffset(string id, Vector3 offset)
+        {
+            GooglyEyeOffsets.Add(id, offset);
         }
     }
 }

--- a/TrainworksModdingTools/Managers/PluginManager.cs
+++ b/TrainworksModdingTools/Managers/PluginManager.cs
@@ -61,5 +61,13 @@ namespace Trainworks.Managers
             PluginGUIDToPath[plugin.Info.Metadata.GUID] = path;
             AssemblyNameToPluginGUID[assembly.FullName] = plugin.Info.Metadata.GUID;
         }
+        /// <summary>
+        /// Test if a BepinEx mod is available.
+        /// </summary>
+        /// <param name="guid">The Mod's GUID string</param>
+        public static bool PluginExists(string guid)
+        {
+            return PluginGUIDToPath.ContainsKey(guid);
+        }
     }
 }

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.7";
+        public const string VERSION = "2.2.8";
 
         /// <summary>
         /// The framework's logging source.

--- a/TrainworksModdingTools/Utilities/AssetLoadingInfo.cs
+++ b/TrainworksModdingTools/Utilities/AssetLoadingInfo.cs
@@ -43,6 +43,12 @@ namespace Trainworks.Utilities
         public ISettings ImportSettings { get; set; }
 
         /// <summary>
+        /// Base name of the asset. Defaults to the SpriteName's filename without extension.
+        /// This should be set for easier debugging with the Runtime Unity editor
+        /// </summary>
+        public string BaseName { get; set; }
+
+        /// <summary>
         /// Path to the asset sprite in the bundle.
         /// Even if you're making a spine character, you *must* set this for the preview sprite.
         /// </summary>
@@ -50,7 +56,15 @@ namespace Trainworks.Utilities
 
         /// <summary>
         /// Optional path to the spine skeleton data in the bundle.
+        /// Deprecated in favor of SpineAnimationDict, since this property only specifies a singular SkeletonAnimation GameObject.
+        /// This should be only used by the Arcadian Clan
         /// </summary>
         public string ObjectName { get; set; }
+
+        /// <summary>
+        /// Optional paths mapping the Animation to the Spine Skeleton Data in the bundle.
+        /// This is preferred over ObjectName as you can specify all 6 SkeletonAnimations for your character with this property.
+        /// </summary>
+        public IDictionary<CharacterUI.Anim, string> SpineAnimationDict { get; set; }
     }
 }


### PR DESCRIPTION
- Add PluginManager.PluginExists(guid)
- Fixes for ScenarioDataBuilder BossPortrait was set to Boss Icon.
- Introduce XXXSpritePath for ScenarioDataBuilder and form the MapNodeIcon from the sprite paths given.
- Add CustomCharacterManager.IsCustomCharacter
- Partial support for GooglyEye modification. (unimplemented)