### PR TITLE
Version 2.3.0 / Custom Effects

### DIFF
--- a/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitAttackSafely.cs
+++ b/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitAttackSafely.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Trainworks;
+
+namespace Trainworks.CustomCardTraits
+{
+    /// <summary>
+    /// Card Trait that handles scaling a Unit's attack stat, safely.
+    /// This CardTrait should only be used on Cards which spawn units.
+    /// The issue with using a CardTrait on a Unit card which scales is that it indiscrimanitely scales
+    /// *every* upgrade the unit applies to itself (or others), which may not be the intended effect.
+    /// 
+    /// The famous example Kinhost Carapace + Heaven's Aid (Revenge: +1 Attack) buff.
+    /// Since the Trigger added by the Heaven's Aid upgrade applies a card upgrade to units,
+    /// the upgrade is modified by the Card Trait on Kinhost Carapace.
+    /// 
+    /// 
+    /// Note that Spell cards which applies upgrades are unaffected since the CardTraits on the played
+    /// card modify the upgrade applied, not the Card traits on the unit on which the upgrade is applied to.
+    /// 
+    /// Required Params: 
+    ///     ParamTrackedValue - TrackedValue statistic to use.
+    ///     ParamEntryDuration - Duration for the TrackedValue statistic
+    ///     ParamInt - Attack multiplier applied to the tracked value and added to the upgrade.
+    ///     ParamCardUpgradeData - CardUpgradeData this Trait applies to.
+    /// </summary>
+    public sealed class CardTraitScalingUpgradeUnitAttackSafely : CardTraitState
+    {
+        public override void OnApplyingCardUpgradeToUnit(CardState thisCard, CharacterState targetUnit, CardUpgradeState upgradeState, CardManager cardManager)
+        {
+            if (GetCardTraitData().GetCardUpgradeDataParam().GetAssetKey() != upgradeState.GetAssetName())
+            {
+                return;
+            }
+            int attackDamage = upgradeState.GetAttackDamage();
+            int additionalDamage = GetAdditionalDamage(cardManager.GetCardStatistics(), setForPreviewText: false);
+            upgradeState.SetAttackDamage(attackDamage + additionalDamage);
+        }
+
+        private int GetAdditionalDamage(CardStatistics cardStatistics, bool setForPreviewText)
+        {
+            CardStatistics.StatValueData statValueData = default(CardStatistics.StatValueData);
+            statValueData.cardState = GetCard();
+            statValueData.trackedValue = GetParamTrackedValue();
+            statValueData.entryDuration = GetParamEntryDuration();
+            statValueData.cardTypeTarget = GetParamCardType();
+            statValueData.paramSubtype = GetParamSubtype();
+            statValueData.forPreviewText = setForPreviewText;
+            CardStatistics.StatValueData statValueData2 = statValueData;
+            int statValue = cardStatistics.GetStatValue(statValueData2);
+            return GetParamInt() * statValue;
+        }
+
+        public override string GetCurrentEffectText(CardStatistics cardStatistics, SaveManager saveManager, RelicManager relicManager)
+        {
+            if (cardStatistics != null && cardStatistics.GetStatValueShouldDisplayOnCardNow(base.StatValueData))
+            {
+                return string.Format("CardTraitScalingUpgradeUnitAttack_CurrentScaling_CardText".Localize(), GetAdditionalDamage(cardStatistics, setForPreviewText: true));
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitHealthSafely.cs
+++ b/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitHealthSafely.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Trainworks.CustomCardTraits
+{
+    /// <summary>
+    /// Card Trait that handles scaling a Unit's health stat, safely.
+    /// This CardTrait should only be used on Cards which spawn units.
+    /// The issue with using a CardTrait on a Unit card which scales is that it indiscrimanitely scales
+    /// *every* upgrade the unit applies to itself (or others), which may not be the intended effect.
+    /// 
+    /// The famous example Kinhost Carapace + Heaven's Aid (Revenge: +1 Attack) buff.
+    /// Since the Trigger added by the Heaven's Aid upgrade applies a card upgrade to units,
+    /// the upgrade is modified by the Card Trait on Kinhost Carapace.
+    /// 
+    /// 
+    /// Note that Spell cards which applies upgrades are unaffected since the CardTraits on the played
+    /// card modify the upgrade applied, not the Card traits on the unit on which the upgrade is applied to.
+    /// 
+    /// Required Params: 
+    ///     ParamTrackedValue - TrackedValue statistic to use
+    ///     ParamEntryDuration - Duration for the TrackedValue statistic.
+    ///     ParamInt - HP multiplier applied to the tracked value and added to the upgrade.
+    ///     ParamCardUpgradeData - CardUpgradeData that this card trait should apply to.
+    /// </summary>
+    public sealed class CardTraitScalingUpgradeUnitHealthSafely : CardTraitState
+    {
+        public override void OnApplyingCardUpgradeToUnit(CardState thisCard, CharacterState targetUnit, CardUpgradeState upgradeState, CardManager cardManager)
+        {
+            if (GetCardTraitData().GetCardUpgradeDataParam().GetAssetKey() != upgradeState.GetAssetName())
+            {
+                return;
+            }
+            int additionalHP = upgradeState.GetAdditionalHP();
+            int additionalHealth = GetAdditionalHealth(cardManager.GetCardStatistics(), setForPreviewText: false);
+            upgradeState.SetAdditionalHP(additionalHP + additionalHealth);
+        }
+
+        private int GetAdditionalHealth(CardStatistics cardStatistics, bool setForPreviewText)
+        {
+            CardStatistics.StatValueData statValueData = default(CardStatistics.StatValueData);
+            statValueData.cardState = GetCard();
+            statValueData.trackedValue = GetParamTrackedValue();
+            statValueData.entryDuration = GetParamEntryDuration();
+            statValueData.cardTypeTarget = GetParamCardType();
+            statValueData.paramSubtype = GetParamSubtype();
+            statValueData.forPreviewText = setForPreviewText;
+            CardStatistics.StatValueData statValueData2 = statValueData;
+            int statValue = cardStatistics.GetStatValue(statValueData2);
+            return GetParamInt() * statValue;
+        }
+
+        public override string GetCurrentEffectText(CardStatistics cardStatistics, SaveManager saveManager, RelicManager relicManager)
+        {
+            if (cardStatistics != null && cardStatistics.GetStatValueShouldDisplayOnCardNow(base.StatValueData))
+            {
+                return string.Format("CardTraitScalingUpgradeUnitHealth_CurrentScaling_CardText".Localize(), GetAdditionalHealth(cardStatistics, setForPreviewText: true));
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitSizeSafely.cs
+++ b/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitSizeSafely.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Trainworks.CustomCardTraits
+{
+    /// <summary>
+    /// Card Trait that handles scaling a Unit's size, safely.
+    /// This CardTrait should only be used on Cards which spawn units.
+    /// The issue with using a CardTrait on a Unit card which scales is that it indiscrimanitely scales
+    /// *every* upgrade the unit applies to itself (or others), which may not be the intended effect.
+    /// 
+    /// The famous example Kinhost Carapace + Heaven's Aid (Revenge: +1 Attack) buff.
+    /// Since the Trigger added by the Heaven's Aid upgrade applies a card upgrade to units,
+    /// the upgrade is modified by the Card Trait on Kinhost Carapace.
+    /// 
+    /// 
+    /// Note that Spell cards which applies upgrades are unaffected since the CardTraits on the played
+    /// card modify the upgrade applied, not the Card traits on the unit on which the upgrade is applied to.
+    /// 
+    /// Required Params:
+    ///     ParamTrackedValue - TrackedValue statistic to use
+    ///     ParamEntryDuration - Duration for the TrackedValue statistic.
+    ///     ParamInt - Size multiplier applied to the tracked value and added to the upgrade.
+    ///     ParamCardUpgradeData - CardUpgradeData that this card trait should apply to.
+    /// </summary>
+    public sealed class CardTraitScalingUpgradeUnitSizeSafely : CardTraitState
+    {
+        public override void OnApplyingCardUpgradeToUnit(CardState thisCard, CharacterState targetUnit, CardUpgradeState upgradeState, CardManager cardManager)
+        {
+            if (GetCardTraitData().GetCardUpgradeDataParam().GetAssetKey() != upgradeState.GetAssetName())
+            {
+                return;
+            }
+            int additionalSize = upgradeState.GetAdditionalSize();
+            int additionalSize2 = GetAdditionalSize(cardManager.GetCardStatistics(), setForPreviewText: false);
+            upgradeState.SetAdditionalSize(additionalSize + additionalSize2);
+        }
+
+        private int GetAdditionalSize(CardStatistics cardStatistics, bool setForPreviewText)
+        {
+            CardStatistics.StatValueData statValueData = default(CardStatistics.StatValueData);
+            statValueData.cardState = GetCard();
+            statValueData.trackedValue = GetParamTrackedValue();
+            statValueData.entryDuration = GetParamEntryDuration();
+            statValueData.cardTypeTarget = GetParamCardType();
+            statValueData.paramSubtype = GetParamSubtype();
+            statValueData.forPreviewText = setForPreviewText;
+            CardStatistics.StatValueData statValueData2 = statValueData;
+            int statValue = cardStatistics.GetStatValue(statValueData2);
+            return GetParamInt() * statValue;
+        }
+
+        public override string GetCurrentEffectText(CardStatistics cardStatistics, SaveManager saveManager, RelicManager relicManager)
+        {
+            if (cardStatistics != null && cardStatistics.GetStatValueShouldDisplayOnCardNow(base.StatValueData))
+            {
+                return string.Format("CardTraitScalingUpgradeUnitSize_CurrentScaling_CardText".Localize(), GetAdditionalSize(cardStatistics, setForPreviewText: true));
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitStatusEffectSafely.cs
+++ b/TrainworksModdingTools/Custom/CardTraits/CardTraitScalingUpgradeUnitStatusEffectSafely.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Trainworks.CustomCardTraits
+{
+    /// <summary>
+    /// Card Trait that handles scaling a Unit's status effects, safely.
+    /// This CardTrait should only be used on Cards which spawn units.
+    /// The issue with using a CardTrait on a Unit card which scales is that it indiscrimanitely scales
+    /// *every* upgrade the unit applies to itself (or others), which may not be the intended effect.
+    /// 
+    /// The famous example Kinhost Carapace + Heaven's Aid (Revenge: +1 Attack) buff.
+    /// Since the Trigger added by the Heaven's Aid upgrade applies a card upgrade to units,
+    /// the upgrade is modified by the Card Trait on Kinhost Carapace.
+    /// 
+    /// 
+    /// Note that Spell cards which applies upgrades are unaffected since the CardTraits on the played
+    /// card modify the upgrade applied, not the Card traits on the unit on which the upgrade is applied to.
+    /// 
+    /// Required Params:
+    ///     ParamTrackedValue - TrackedValue statistic to use.
+    ///     ParamEntryDuration - Duration for the TrackedValue statistic.
+    ///     ParamInt - Size multiplier applied to the tracked value and added to the upgrade.
+    ///     ParamCardUpgradeData - CardUpgradeData that this card trait should apply to.
+    ///     ParamStatusEffects - Status Effects to add. Note that if the status effect is not present in the upgrade it will be added.
+    /// </summary>
+    public sealed class CardTraitScalingUpgradeUnitStatusEffectSafely : CardTraitState
+    {
+        public override void OnApplyingCardUpgradeToUnit(CardState thisCard, CharacterState targetUnit, CardUpgradeState upgradeState, CardManager cardManager)
+        {
+            if (GetCardTraitData().GetCardUpgradeDataParam().GetAssetKey() != upgradeState.GetAssetName())
+            {
+                return;
+            }
+            int additionalStacks = GetAdditionalStacks(cardManager.GetCardStatistics());
+            StatusEffectStackData[] array = GetParamStatusEffects();
+            foreach (StatusEffectStackData statusEffectStackData in array)
+            {
+                upgradeState.AddStatusEffectUpgradeStacks(statusEffectStackData.statusId, additionalStacks);
+            }
+        }
+
+        private int GetAdditionalStacks(CardStatistics cardStatistics)
+        {
+            CardStatistics.StatValueData statValueData = default(CardStatistics.StatValueData);
+            statValueData.cardState = GetCard();
+            statValueData.trackedValue = GetParamTrackedValue();
+            statValueData.entryDuration = GetParamEntryDuration();
+            statValueData.cardTypeTarget = GetParamCardType();
+            statValueData.paramSubtype = GetParamSubtype();
+            CardStatistics.StatValueData statValueData2 = statValueData;
+            int statValue = cardStatistics.GetStatValue(statValueData2);
+            return GetParamInt() * statValue;
+        }
+
+        public override string GetCurrentEffectText(CardStatistics cardStatistics, SaveManager saveManager, RelicManager relicManager)
+        {
+            if (cardStatistics != null && cardStatistics.GetStatValueShouldDisplayOnCardNow(base.StatValueData))
+            {
+                return string.Format("CardTraitScalingAddStatusEffect_CurrentScaling_CardText".Localize(), GetAdditionalStacks(cardStatistics));
+            }
+            return string.Empty;
+        }
+    }
+
+}

--- a/TrainworksModdingTools/Custom/RelicEffects/IPostStartOfRunRelicEffect.cs
+++ b/TrainworksModdingTools/Custom/RelicEffects/IPostStartOfRunRelicEffect.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+
+namespace Trainworks.CustomRelicEffects
+{
+    /// <summary>
+    /// Interface for a RelicEffect that runs its effects after a new run has been setup.
+    /// 
+    /// Very useful for the StarterRelics param for Custom clans that want to modify the starter deck.
+    /// A good example is a Wurmkin-like Relic that setups the deck and gives Starter Cards Infused.
+    /// 
+    /// If you use StarterRelics the artifacts specified will be given *AT THE VERY START* of a run
+    /// before the Convenants are setup. This is an issue since the Covenants effects will run and  will
+    /// remove all cards and then add the appropriate starter deck afterward thus negating any modifications 
+    /// you did to the starter deck.
+    /// </summary>
+    interface IPostStartOfRunRelicEffect : IRelicEffect
+    {
+        void ApplyEffect(RelicEffectParams param);
+    }
+}

--- a/TrainworksModdingTools/Patches/ApplyStartOfRunRelicEffectsPatch.cs
+++ b/TrainworksModdingTools/Patches/ApplyStartOfRunRelicEffectsPatch.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Trainworks.CustomRelicEffects;
+
+namespace Trainworks.Patches
+{
+    /// <summary>
+    /// Implementation of IPostStartOfRunRelicEffect.
+    /// </summary>
+    [HarmonyPatch(typeof(RelicManager), nameof(RelicManager.ApplyStartOfRunRelicEffects))]
+    class ApplyStartOfRunRelicEffectsPatch
+    {
+        public static void Postfix(SaveManager ___saveManager, RelicEffectParams ___relicEffectParams)
+        {
+            foreach (RelicState currentRelic in ___saveManager.GetAllRelics())
+            {
+                foreach (IRelicEffect effect in currentRelic.GetEffects())
+                {
+                    if (effect is IPostStartOfRunRelicEffect postStartOfRunRelicEffect)
+                    {
+                        postStartOfRunRelicEffect.ApplyEffect(___relicEffectParams);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TrainworksModdingTools/TrainworksModdingTools.cs
+++ b/TrainworksModdingTools/TrainworksModdingTools.cs
@@ -24,7 +24,7 @@ namespace Trainworks
     {
         public const string GUID = "tools.modding.trainworks";
         public const string NAME = "Trainworks Modding Tools";
-        public const string VERSION = "2.2.8";
+        public const string VERSION = "2.3.0";
 
         /// <summary>
         /// The framework's logging source.

--- a/TrainworksModdingTools/TrainworksModdingTools.csproj
+++ b/TrainworksModdingTools/TrainworksModdingTools.csproj
@@ -73,4 +73,9 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Custom\RelicEffects\" />
+    <Folder Include="Custom\CardTraits\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Add a few CustomEffects that would be useful for mods out of the box.

* CardTraitScalingUpgradeUnitXXXSafely.
These are for creating Units that need to apply a scaled upgrade to themselves or others. A common use case is cards like Kinhost Carapace, which apply an upgrade to itself when summoned. The base game's card has a bug, though, in which any CardUpgrade (that's not a Unit Essence) that Kinhost Carapace applies to itself or others gets its scaling benefit. The only way to do this with the base game is with the Heaven's Aid Revenge: +1 Attack upgrade. However, theoretically, one could make an Enhancer that does similar and have it break.

To prevent future mods from making this simple mistake, these CardTraits are provided. They work the same way, except the CardTrait will now only modify the ParamCardUpgradeData specified in the CardTraitData.

* IPostStartOFRunRelicEffect
This relic interface is for RelicEffects, which must run at the very start of the game after applying Covenants, Mutators, etc. The use case for this is an artifact as Wurmtooth describes itself (it actually does nothing), and it is provided as a StarterRelic for a custom clan. The issue with using StarterRelics is that it is given *AT THE VERY START* before Covenants are applied. That is an issue since the Convenents removed all the cards from the starter deck and built a new starter deck, thus negating any modifications the StarterRelic has.