### PR TITLE
Minor fixes

### DIFF
--- a/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CardArtAssetConstructor.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using Trainworks.Managers;
 using Trainworks.Utilities;
 using Trainworks.Interfaces;
+using BepInEx.Logging;
 
 namespace Trainworks.AssetConstructors
 {
@@ -77,7 +78,7 @@ namespace Trainworks.AssetConstructors
                     return gameObject;
                 }
             }
-            Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Invalid asset type " + asset.GetType() + " when loading asset: " + bundleInfo.SpriteName);
+            Trainworks.Log(LogLevel.Error, "Invalid asset type " + asset.GetType() + " when loading asset: " + bundleInfo.SpriteName);
             return null;
         }
     }

--- a/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
+++ b/TrainworksModdingTools/AssetConstructors/CharacterAssetConstructor.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using ShinyShoe;
 using System.IO;
+using BepInEx.Logging;
 
 namespace Trainworks.AssetConstructors
 {
@@ -39,7 +40,7 @@ namespace Trainworks.AssetConstructors
             Sprite sprite = CustomAssetManager.LoadSpriteFromRuntimeKey(assetRef.RuntimeKey);
             if (sprite == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Could not find sprite with asset runtime key: " + assetRef.RuntimeKey);
+                Trainworks.Log(LogLevel.Error, "Could not find sprite with asset runtime key: " + assetRef.RuntimeKey);
                 return null;
             }
             var charObj = CreateCharacterGameObject(assetRef, sprite);
@@ -52,7 +53,7 @@ namespace Trainworks.AssetConstructors
             var tex = BundleManager.LoadAssetFromBundle(bundleInfo, bundleInfo.SpriteName) as Texture2D;
             if (tex == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Invalid sprite name when loading asset: " + bundleInfo.SpriteName);
+                Trainworks.Log(LogLevel.Error, "Invalid sprite name when loading asset: " + bundleInfo.SpriteName);
                 return null;
             }
 
@@ -70,14 +71,14 @@ namespace Trainworks.AssetConstructors
                     GameObject gameObject = BundleManager.LoadAssetFromBundle(bundleInfo, anim_path.Value) as GameObject;
                     if (gameObject == null)
                     {
-                        Trainworks.Log("Could not load spine animation anim: " + anim_path.Key + " path: " + anim_path.Value);
+                        Trainworks.Log(LogLevel.Error, "Could not load spine animation anim: " + anim_path.Key + " path: " + anim_path.Value);
                         continue;
                     }
                     loadedAnims.Add(anim_path.Key, gameObject);
                 }
                 if (loadedAnims.IsNullOrEmpty())
                 {
-                    Trainworks.Log("Failed to load any animations for " + bundleInfo.SpriteName);
+                    Trainworks.Log(LogLevel.Error, "Failed to load any animations for " + bundleInfo.SpriteName);
                     var charObj = CreateCharacterGameObject(assetRef, sprite);
                     GameObject.DontDestroyOnLoad(charObj);
                     return charObj;
@@ -89,11 +90,11 @@ namespace Trainworks.AssetConstructors
             // Legacy. Animated sprite asset with a single spine animation.
             else if (bundleInfo.ObjectName != null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Looking in bundle for... " + bundleInfo.ObjectName);
+                Trainworks.Log(LogLevel.Debug, "Looking in bundle for... " + bundleInfo.ObjectName);
                 GameObject gameObject = BundleManager.LoadAssetFromBundle(bundleInfo, bundleInfo.ObjectName) as GameObject;
                 if (gameObject == null)
                 {
-                    Trainworks.Log("Could not load spine animations for bundle object: " + bundleInfo.ObjectName);
+                    Trainworks.Log(LogLevel.Error, "Could not load spine animations for bundle object: " + bundleInfo.ObjectName);
                     var charObj = CreateCharacterGameObject(assetRef, sprite);
                     GameObject.DontDestroyOnLoad(charObj);
                     return charObj;

--- a/TrainworksModdingTools/BuildersV2/CardEffectDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardEffectDataBuilder.cs
@@ -279,6 +279,7 @@ namespace Trainworks.BuildersV2
             AccessTools.Field(typeof(CardEffectData), "paramCardUpgradeData").SetValue(cardEffectData, upgrade);
 
             // Field not allocated.
+            // TODO don't allocate if it isn't needed.
             var characterDataPool = new List<CharacterData>();
             characterDataPool.AddRange(ParamCharacterDataPool);
             foreach (var character in ParamCharacterDataPoolBuilder)

--- a/TrainworksModdingTools/BuildersV2/CardTriggerEffectDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardTriggerEffectDataBuilder.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Logging;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 
@@ -70,8 +71,8 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (TriggerID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a TriggerID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(LogLevel.Error, "Warning should provide a TriggerID.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             // Doesn't inherit from ScriptableObject
@@ -106,12 +107,13 @@ namespace Trainworks.BuildersV2
         /// <returns></returns>
         public CardTriggerData AddCardTrigger(PersistenceMode persistenceMode, string cardTriggerEffect, string buffEffectType, int paramInt)
         {
-            CardTriggerData trigger = new CardTriggerData();
-
-            trigger.persistenceMode = persistenceMode;
-            trigger.cardTriggerEffect = cardTriggerEffect;
-            trigger.buffEffectType = buffEffectType;
-            trigger.paramInt = paramInt;
+            CardTriggerData trigger = new CardTriggerData
+            {
+                persistenceMode = persistenceMode,
+                cardTriggerEffect = cardTriggerEffect,
+                buffEffectType = buffEffectType,
+                paramInt = paramInt
+            };
 
             CardTriggerEffects.Add(trigger);
             return trigger;
@@ -127,12 +129,13 @@ namespace Trainworks.BuildersV2
         /// <returns></returns>
         public static CardTriggerData MakeCardTrigger(PersistenceMode persistenceMode, string cardTriggerEffect, string buffEffectType, int paramInt)
         {
-            CardTriggerData trigger = new CardTriggerData();
-
-            trigger.persistenceMode = persistenceMode;
-            trigger.cardTriggerEffect = cardTriggerEffect;
-            trigger.buffEffectType = buffEffectType;
-            trigger.paramInt = paramInt;
+            CardTriggerData trigger = new CardTriggerData
+            {
+                persistenceMode = persistenceMode,
+                cardTriggerEffect = cardTriggerEffect,
+                buffEffectType = buffEffectType,
+                paramInt = paramInt
+            };
 
             return trigger;
         }

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
@@ -242,8 +242,8 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (UpgradeID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a UpgradeID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(BepInEx.Logging.LogLevel.Error, "Warning should provide a UpgradeID.");
+                Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             CardUpgradeData cardUpgradeData = ScriptableObject.CreateInstance<CardUpgradeData>();

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
@@ -156,11 +156,14 @@ namespace Trainworks.BuildersV2
         public List<CardUpgradeMaskData> Filters { get; set; }
         /// <summary>
         /// Upgrades to remove when this upgrade is applied.
-        /// Not commonly used. The main use case in the MT codebase is to remove a startingUpgrade from a card.
+        /// Not commonly used. The most common use case in the MT codebase is to remove a startingUpgrade from a card.
         /// The only use of this parameter is in the upgraded Spikedriver Colony and Improved Spikedriver
         /// to remove the self-duplication from the card.
         /// With primordium's superfood upgrade path, it removes the startingUpgrade from the card which
         /// effectively replaces the OnEaten effect to include the Stats and the Status Effects.
+        /// Rarely, this is used to remove a previous champion upgrade. If your Champion Upgrade includes a CardTrait
+        /// or CardTriggerUpgrade which are upgrades applied to the Card, then you will need to use this to remove
+        /// said CardTrait or CardTriggerUpgrade since these aren't removed automatically. (See: LittleFade's Spikes Path).
         /// </summary>
         public List<CardUpgradeData> UpgradesToRemove { get; set; }
         /// <summary>

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeDataBuilder.cs
@@ -176,6 +176,8 @@ namespace Trainworks.BuildersV2
         public bool IsUnitSynthesisUpgrade { get => SourceSynthesisUnit != null; }
         /// <summary>
         /// Indicates that the upgrade can only be applied to a card/unit once.
+        /// Rarely used. This is used for Relics that apply TempCardUpgrades to cards.
+        /// See: Channelheart and Thorn Casing.
         /// </summary>
         public bool IsUnique { get; set; }
         /// <summary>

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeMaskDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeMaskDataBuilder.cs
@@ -73,35 +73,35 @@ namespace Trainworks.BuildersV2
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator RequiredSubtypesOperator { get; set; }
+        public CompareOperator RequiredSubtypesOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator ExcludedSubtypesOperator { get; set; }
+        public CompareOperator ExcludedSubtypesOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator RequiredStatusEffectsOperator { get; set; }
+        public CompareOperator RequiredStatusEffectsOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator ExcludedStatusEffectsOperator { get; set; }
+        public CompareOperator ExcludedStatusEffectsOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator RequiredCardTraitsOperator { get; set; }
+        public CompareOperator RequiredCardTraitsOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator ExcludedCardTraitsOperator { get; set; }
+        public CompareOperator ExcludedCardTraitsOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator RequiredCardEffectsOperator { get; set; }
+        public CompareOperator RequiredCardEffectsOperator { get; set; }
         /// <summary>
         /// Operator determines if we require all or at least one
         /// </summary>
-        public CardUpgradeMaskDataBuilder.CompareOperator ExcludedCardEffectsOperator { get; set; }
+        public CompareOperator ExcludedCardEffectsOperator { get; set; }
         /// <summary>
         /// Allows the upgrade to be only applied to X cost cards.
         /// </summary>
@@ -110,6 +110,10 @@ namespace Trainworks.BuildersV2
         /// Disallows X cost cards from receiving the upgrade.
         /// </summary>
         public bool ExcludeXCost { get; set; }
+        /// <summary>
+        /// Excludes a unit if it has a synthesis. Currently only used at Divine Temple.
+        /// </summary>
+        public bool ExcludeIfUnitSynthesized { get; set; }
         /// <summary>
         /// This is the reason why a card is filtered away from having this upgrade applied to it
         /// </summary>
@@ -160,6 +164,7 @@ namespace Trainworks.BuildersV2
             AccessTools.Field(typeof(CardUpgradeMaskData), "excludedSubtypesOperator").SetValue(cardUpgradeMaskData, Enum.ToObject(realEnumType, ExcludedSubtypesOperator));
             AccessTools.Field(typeof(CardUpgradeMaskData), "excludeNonAttackingMonsters").SetValue(cardUpgradeMaskData, ExcludeNonAttackingMonsters);
             AccessTools.Field(typeof(CardUpgradeMaskData), "excludeXCost").SetValue(cardUpgradeMaskData, ExcludeXCost);
+            AccessTools.Field(typeof(CardUpgradeMaskData), "excludeIfUnitSynthesized").SetValue(cardUpgradeMaskData, ExcludeIfUnitSynthesized);
             AccessTools.Field(typeof(CardUpgradeMaskData), "requiredCardEffects").SetValue(cardUpgradeMaskData, RequiredCardEffects);
             AccessTools.Field(typeof(CardUpgradeMaskData), "requiredCardEffectsOperator").SetValue(cardUpgradeMaskData, Enum.ToObject(realEnumType, RequiredCardEffectsOperator));
             AccessTools.Field(typeof(CardUpgradeMaskData), "requiredCardTraits").SetValue(cardUpgradeMaskData, RequiredCardTraits);

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeMaskDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeMaskDataBuilder.cs
@@ -112,6 +112,11 @@ namespace Trainworks.BuildersV2
         public bool ExcludeXCost { get; set; }
         /// <summary>
         /// Excludes a unit if it has a synthesis. Currently only used at Divine Temple.
+        /// If using this for a in battle upgrade to a non synthesized unit, the result will
+        /// be unreliable. Some Card Upgrades (that aren't essences) in the Vanilla game (and mods)
+        /// have the IsUnitSynthesis flag set as a bandage for the bugged unit Kinhost Carapace.
+        /// 
+        /// Without it Kinhost Carapace will scale any upgrade it applies to itself or others.
         /// </summary>
         public bool ExcludeIfUnitSynthesized { get; set; }
         /// <summary>
@@ -142,8 +147,9 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (CardUpgradeMaskID == null)
             {
+                // Doesn't effect localization so keeping to Warning level.
                 Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a CardUpgradeMaskDataID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             CardUpgradeMaskData cardUpgradeMaskData = ScriptableObject.CreateInstance<CardUpgradeMaskData>();

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeTreeDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeTreeDataBuilder.cs
@@ -24,6 +24,10 @@ namespace Trainworks.BuildersV2
         /// Then the Superfood II upgrade is applied and then the Aggressive Edible I upgrade is applied.
         /// </summary>
         public List<List<CardUpgradeDataBuilder>> UpgradeTrees { get; set; } = new List<List<CardUpgradeDataBuilder>>();
+        /// <summary>
+        /// Alternative list of lists of CardUpgradeDatas. UpgradeTrees will be merged with these lists.
+        /// </summary>
+        public List<List<CardUpgradeData>> UpgradesTreeDatas { get; set; }
 
         public CardUpgradeTreeData Build()
         {
@@ -33,17 +37,30 @@ namespace Trainworks.BuildersV2
             {
                 List<CardUpgradeTreeData.UpgradeTree> upgradeTrees = cardUpgradeTreeData.GetUpgradeTrees();
 
-                foreach (List<CardUpgradeDataBuilder> branch in UpgradeTrees)
+                if (!UpgradesTreeDatas.IsNullOrEmpty())
                 {
-                    CardUpgradeTreeData.UpgradeTree newBranch = new CardUpgradeTreeData.UpgradeTree();
-                    List<CardUpgradeData> newbranchlist = newBranch.GetCardUpgrades();
-
-                    foreach (CardUpgradeDataBuilder leaf in branch)
+                    foreach (List<CardUpgradeData> branch in UpgradesTreeDatas)
                     {
-                        newbranchlist.Add(leaf.Build());
+                        CardUpgradeTreeData.UpgradeTree newBranch = new CardUpgradeTreeData.UpgradeTree();
+                        List<CardUpgradeData> newbranchlist = newBranch.GetCardUpgrades();
+                        newbranchlist.AddRange(branch);
+                        upgradeTrees.Add(newBranch);
                     }
+                }
+                if (!UpgradeTrees.IsNullOrEmpty())
+                {
+                    foreach (List<CardUpgradeDataBuilder> branch in UpgradeTrees)
+                    {
+                        CardUpgradeTreeData.UpgradeTree newBranch = new CardUpgradeTreeData.UpgradeTree();
+                        List<CardUpgradeData> newbranchlist = newBranch.GetCardUpgrades();
 
-                    upgradeTrees.Add(newBranch);
+                        foreach (CardUpgradeDataBuilder leaf in branch)
+                        {
+                            newbranchlist.Add(leaf.Build());
+                        }
+
+                        upgradeTrees.Add(newBranch);
+                    }
                 }
             }
             else

--- a/TrainworksModdingTools/BuildersV2/CardUpgradeTreeDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CardUpgradeTreeDataBuilder.cs
@@ -18,10 +18,14 @@ namespace Trainworks.BuildersV2
         /// <summary>
         /// This is a list of lists of CardUpgradeDataBuilders. Base game clans have a 3x3 list.
         /// Note that the way these Upgrades are applied.
+        /// 
         /// For instance If I have Primordium and I have Superfood II, only the upgrade corresponding to Superfood II is applied.
         /// That is when you select an upgraded path, the previous version is removed and the upgraded version is applied.
         /// If you mix paths then the upgrade corresponding to each split path is applied. That is if I am Superfood II and Aggressive Edible I
         /// Then the Superfood II upgrade is applied and then the Aggressive Edible I upgrade is applied.
+        /// 
+        /// Note that upgrades applied to the Card are not automatically removed. For that use UpgradesToRemove.
+        /// See Lil Fade's spikes path for an example.
         /// </summary>
         public List<List<CardUpgradeDataBuilder>> UpgradeTrees { get; set; } = new List<List<CardUpgradeDataBuilder>>();
         /// <summary>

--- a/TrainworksModdingTools/BuildersV2/CharacterChatterDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CharacterChatterDataBuilder.cs
@@ -78,9 +78,9 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (ChatterID == null)
             {
+                // Doesn't affect localization keys so keeping at warning.
                 Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a ChatterID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
-
+                Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             CharacterChatterData chatter = ScriptableObject.CreateInstance<CharacterChatterData>();

--- a/TrainworksModdingTools/BuildersV2/CharacterTriggerDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/CharacterTriggerDataBuilder.cs
@@ -76,8 +76,8 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (TriggerID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a TriggerID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(BepInEx.Logging.LogLevel.Error, "Warning should provide a TriggerID.");
+                Trainworks.Log(BepInEx.Logging.LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             CharacterTriggerData characterTriggerData = new CharacterTriggerData(Trigger, /* cardEffectData = */null);

--- a/TrainworksModdingTools/BuildersV2/ClassDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/ClassDataBuilder.cs
@@ -114,6 +114,8 @@ namespace Trainworks.BuildersV2
         /// Not important for many RelicEffect Interfaces, but do note that the Covenants are implemented
         /// as Relics. So things like applying additional effects the starter deck can't be done easily without
         /// a patch, Since Covenant 1 removes all starter cards, and adds them back with a CardSet.
+        /// 
+        /// See: IPostStartOfRunRelicEffect.
         /// </summary>
         public List<RelicData> StarterRelics { get; set; }
         /// <summary>

--- a/TrainworksModdingTools/BuildersV2/EnhancerPoolBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/EnhancerPoolBuilder.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Logging;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using Trainworks.ManagersV2;
@@ -49,8 +50,9 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (EnhancerPoolID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a EnhancerPoolID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                // Doesn't affect localization keys so setting to warning.
+                Trainworks.Log(LogLevel.Warning, "Warning should provide a EnhancerPoolID.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             EnhancerPool enhancerPool = ScriptableObject.CreateInstance<EnhancerPool>();

--- a/TrainworksModdingTools/BuildersV2/GoldRewardDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/GoldRewardDataBuilder.cs
@@ -39,6 +39,11 @@ namespace Trainworks.BuildersV2
 
         public RewardData Build(bool register = true)
         {
+            if (RewardID == null)
+            {
+                throw new BuilderException("RewardID is required");
+            }
+
             var rewardData = ScriptableObject.CreateInstance<GoldRewardData>();
             rewardData.name = RewardID;
 

--- a/TrainworksModdingTools/BuildersV2/HealthRewardDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/HealthRewardDataBuilder.cs
@@ -39,6 +39,11 @@ namespace Trainworks.BuildersV2
 
         public RewardData Build(bool register = true)
         {
+            if (RewardID == null)
+            {
+                throw new BuilderException("RewardID is required");
+            }
+
             var rewardData = ScriptableObject.CreateInstance<HealthRewardData>();
             rewardData.name = RewardID;
 

--- a/TrainworksModdingTools/BuildersV2/MerchantCharacterDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/MerchantCharacterDataBuilder.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Logging;
+using HarmonyLib;
 using Spine;
 using Spine.Unity;
 using System;
@@ -56,8 +57,9 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (MerchantCharacterID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a MerchantCharacterID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                // May cause lookup errors if not provided.
+                Trainworks.Log(LogLevel.Error, "Warning should provide a MerchantCharacterID.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             var merchant = ScriptableObject.CreateInstance<MerchantCharacterData>();

--- a/TrainworksModdingTools/BuildersV2/PurgeRewardDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/PurgeRewardDataBuilder.cs
@@ -54,6 +54,11 @@ namespace Trainworks.BuildersV2
 
         public RewardData Build(bool register = true)
         {
+            if (RewardID == null)
+            {
+                throw new BuilderException("RewardID is required");
+            }
+
             var rewardData = ScriptableObject.CreateInstance<PurgeRewardData>();
             rewardData.name = RewardID;
 

--- a/TrainworksModdingTools/BuildersV2/RandomChampionPoolBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/RandomChampionPoolBuilder.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Logging;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -31,8 +32,8 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (ChampionPoolID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a ChampionPoolID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(LogLevel.Warning, "Warning should provide a ChampionPoolID.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             RandomChampionPool championPool = ScriptableObject.CreateInstance<RandomChampionPool>();

--- a/TrainworksModdingTools/BuildersV2/RandomRewardDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/RandomRewardDataBuilder.cs
@@ -39,6 +39,11 @@ namespace Trainworks.BuildersV2
 
         public RewardData Build(bool register = true)
         {
+            if (RewardID == null)
+            {
+                throw new BuilderException("RewardID is required");
+            }
+
             var rewardData = ScriptableObject.CreateInstance<RandomRewardData>();
             rewardData.name = RewardID;
 

--- a/TrainworksModdingTools/BuildersV2/RoomModifierDataBuilder.cs
+++ b/TrainworksModdingTools/BuildersV2/RoomModifierDataBuilder.cs
@@ -1,3 +1,4 @@
+using BepInEx.Logging;
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
@@ -136,8 +137,8 @@ namespace Trainworks.BuildersV2
             // Not catastrophic enough to throw an Exception, this should be provided though.
             if (RoomModifierID == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Warning should provide a RoomModifierID.");
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Stacktrace: " + Environment.StackTrace);
+                Trainworks.Log(LogLevel.Error, "Warning should provide a RoomModifierID.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
 
             RoomModifierData roomModifierData = new RoomModifierData();

--- a/TrainworksModdingTools/Enums/ExtendedByteEnum.cs
+++ b/TrainworksModdingTools/Enums/ExtendedByteEnum.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BepInEx.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,15 +37,15 @@ namespace Trainworks.Enums
             this.Name = Name;
             if (NameToExtendedEnumMap.ContainsKey(this.Name))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"Name: {this.Name} Conflict in domain, {typeof(TExtendedEnum).Name}");
+                Trainworks.Log(LogLevel.Warning, $"Name: {this.Name} Conflict in domain, {typeof(TExtendedEnum).Name}");
             }
             if (ByteToExtendedEnumMap.ContainsKey(this.ID))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"ID#{this.ID} Conflict between {Name} and {ByteToExtendedEnumMap[this.ID].Name} in domain, {typeof(TExtendedEnum).Name}");
+                Trainworks.Log(LogLevel.Warning, $"ID#{this.ID} Conflict between {Name} and {ByteToExtendedEnumMap[this.ID].Name} in domain, {typeof(TExtendedEnum).Name}");
             }
             if (ReservedIDs.Contains(this.ID))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"ID#{this.ID} is Reserved and can't be set for {Name}");
+                Trainworks.Log(LogLevel.Warning, $"ID#{this.ID} is Reserved and can't be set for {Name}");
             }
             NameToExtendedEnumMap[Name] = (TExtendedEnum)this;
             ByteToExtendedEnumMap[ID] = (TExtendedEnum)this;

--- a/TrainworksModdingTools/Enums/ExtendedEnum.cs
+++ b/TrainworksModdingTools/Enums/ExtendedEnum.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BepInEx.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,15 +37,15 @@ namespace Trainworks.Enums
             this.Name = Name;
             if (NameToExtendedEnumMap.ContainsKey(this.Name))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"Name: {this.Name} Conflict in domain, {typeof(TExtendedEnum).Name}");
+                Trainworks.Log(LogLevel.Warning, $"Name: {this.Name} Conflict in domain, {typeof(TExtendedEnum).Name}");
             }
             if (IntToExtendedEnumMap.ContainsKey(this.ID))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"ID#{this.ID} Conflict between {Name} and {IntToExtendedEnumMap[this.ID].Name} in domain, {typeof(TExtendedEnum).Name}");
+                Trainworks.Log(LogLevel.Warning, $"ID#{this.ID} Conflict between {Name} and {IntToExtendedEnumMap[this.ID].Name} in domain, {typeof(TExtendedEnum).Name}");
             }
             if (ReservedIDs.Contains(this.ID))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, $"ID#{this.ID} is Reserved and can't be set for {Name}");
+                Trainworks.Log(LogLevel.Warning, $"ID#{this.ID} is Reserved and can't be set for {Name}");
             }
             NameToExtendedEnumMap[Name] = (TExtendedEnum)this;
             IntToExtendedEnumMap[ID] = (TExtendedEnum)this;

--- a/TrainworksModdingTools/Legacy/Patches/ResetUnitSynthesisMapping.cs
+++ b/TrainworksModdingTools/Legacy/Patches/ResetUnitSynthesisMapping.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using Trainworks.Managers;
 using System;
+using BepInEx.Logging;
 
 // Only here for backwards compatibility. This used to recompute the internal unit synthesis mapping dictionary.
 // But it was an inefficient solution requiring it to be called per Plugin which recomputes them all every time.
@@ -11,7 +12,7 @@ namespace Trainworks.Patches
         [Obsolete("AccessUnitSynthesisMapping.FindUnitSynthesisMappingInstanceToStub is deprecated and calls should be removed.")]
         public static void FindUnitSynthesisMappingInstanceToStub()
         {
-            Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "This function is deprecated and calls should be removed.");
+            Trainworks.Log(LogLevel.Warning, "This function is deprecated and calls should be removed.");
         }
     }
 

--- a/TrainworksModdingTools/Managers/BundleManager.cs
+++ b/TrainworksModdingTools/Managers/BundleManager.cs
@@ -12,6 +12,7 @@ using UnityEngine.AddressableAssets;
 using Trainworks.Builders;
 using Trainworks.AssetConstructors;
 using Trainworks.Utilities;
+using BepInEx.Logging;
 
 namespace Trainworks.Managers
 {
@@ -49,7 +50,7 @@ namespace Trainworks.Managers
                 }
                 else
                 {
-                    Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Custom asset bundle failed to load from path: " + path);
+                    Trainworks.Log(LogLevel.Error, "Custom asset bundle failed to load from path: " + path);
                 }
             }
         }
@@ -75,12 +76,12 @@ namespace Trainworks.Managers
                 var asset = LoadedAssetBundles[info.FullPath].LoadAsset(assetName);
                 if (asset == null)
                 {
-                    Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Custom asset: " + assetName + " failed to load from bundle: " + info.FullPath);
+                    Trainworks.Log(LogLevel.Error, "Custom asset: " + assetName + " failed to load from bundle: " + info.FullPath);
                 }
                 ApplyImportSettings(info, ref asset);
                 return asset;
             }
-            Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Attempting to load asset from non-existent bundle: " + info.FullPath);
+            Trainworks.Log(LogLevel.Error, "Attempting to load asset from non-existent bundle: " + info.FullPath);
             return null;
         }
 

--- a/TrainworksModdingTools/Managers/CustomCardManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCardManager.cs
@@ -49,6 +49,7 @@ namespace Trainworks.Managers
         /// <param name="cardPoolData">The card pools the custom card should be a part of</param>
         public static void RegisterCustomCard(CardData cardData, List<string> cardPoolData)
         {
+            ContentValidator.Validate(cardData);
             if (!CustomCardData.ContainsKey(cardData.GetID()))
             {
                 CustomCardData.Add(cardData.GetID(), cardData);

--- a/TrainworksModdingTools/Managers/CustomCardManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCardManager.cs
@@ -8,6 +8,7 @@ using UnityEngine.AddressableAssets;
 using UnityEngine.UI;
 using Trainworks.Utilities;
 using Malee;
+using System;
 
 namespace Trainworks.Managers
 {
@@ -84,7 +85,8 @@ namespace Trainworks.Managers
             var vanillaCard = ProviderManager.SaveManager.GetAllGameData().FindCardData(cardID);
             if (vanillaCard == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find card: " + cardID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find card: " + cardID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaCard;
         }

--- a/TrainworksModdingTools/Managers/CustomCardPoolManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCardPoolManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using BepInEx.Logging;
@@ -34,7 +35,7 @@ namespace Trainworks.Managers
             {
                 return reward.GetDraftPool();
             }
-            Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Could not get MegaPool Instance");
+            Trainworks.Log(LogLevel.Error, "Could not get MegaPool Instance");
             return null;
         }
 
@@ -47,7 +48,7 @@ namespace Trainworks.Managers
             var relic = ProviderManager.SaveManager.GetAllGameData().FindCollectableRelicData(VanillaCollectableRelicIDs.ConscriptionNotice);
             if (relic == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Could not get ConscriptionPool");
+                Trainworks.Log(LogLevel.Error, "Could not get ConscriptionPool");
                 return null;
             }
             return relic.GetFirstRelicEffectData<RelicEffectAddBattleCardToHandOnUnitTrigger>().GetParamCardPool();
@@ -180,7 +181,8 @@ namespace Trainworks.Managers
             {
                 return CustomCardPools[cardPoolID];
             }
-            Trainworks.Log(LogLevel.Warning, "Could not find card pool: " + cardPoolID);
+            Trainworks.Log(LogLevel.Error, "Could not find card pool: " + cardPoolID);
+            Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             return null;
         }
 
@@ -219,7 +221,8 @@ namespace Trainworks.Managers
         {
             if (cardPool == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Attempted to mark a null CardPool for preloading");
+                Trainworks.Log(LogLevel.Error, "Attempted to mark a null CardPool for preloading");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
                 return;
             }
 

--- a/TrainworksModdingTools/Managers/CustomChallengeManager.cs
+++ b/TrainworksModdingTools/Managers/CustomChallengeManager.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx.Logging;
 using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using Trainworks.Managers;
 using Trainworks.Utilities;
@@ -40,7 +41,8 @@ namespace Trainworks.ManagersV2
                 return challenge;
             }
 
-            Trainworks.Log(LogLevel.Warning, "Couldn't find challenge: " + id + " - This will cause crashes.");
+            Trainworks.Log(LogLevel.Error, "Couldn't find challenge: " + id + " - This will cause crashes.");
+            Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             return null;
 
         }

--- a/TrainworksModdingTools/Managers/CustomCharacterManager.cs
+++ b/TrainworksModdingTools/Managers/CustomCharacterManager.cs
@@ -84,7 +84,8 @@ namespace Trainworks.Managers
             });
             if (vanillaChar == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find character: " + characterID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find character: " + characterID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaChar;
         }
@@ -129,7 +130,7 @@ namespace Trainworks.Managers
             TemplateCharacter = asyncOperation.Result;
             if (TemplateCharacter == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Failed to load character template");
+                Trainworks.Log(LogLevel.Error, "Failed to load character template");
             }
         }
 
@@ -166,7 +167,8 @@ namespace Trainworks.Managers
         {
             if (character == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Attempted to mark a null CharacterData for preloading ignoring.");
+                Trainworks.Log(LogLevel.Error, "Attempted to mark a null CharacterData for preloading ignoring.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
                 return;
             }
 
@@ -184,11 +186,9 @@ namespace Trainworks.Managers
 
             if (!CustomCharacterData.ContainsKey(characterData.GetID()))
             {
-                //Trainworks.Log("Not a custom character " + characterData);
                 return null;
             }
 
-            //Trainworks.Log("" + characterData);
             // New Builders should already have this cached.
             if (UnitSynthesisMapping.TryGetValue(characterData, out CardUpgradeData value))
             {
@@ -203,12 +203,9 @@ namespace Trainworks.Managers
                 if (synthesis != null)
                 {
                     UnitSynthesisMapping.Add(characterData, synthesis);
-                    //Trainworks.Log("Synthesis found for unit " + characterData + " " + synthesis);
                     return synthesis;
                 }
             }
-            
-            //Trainworks.Log("No synthesis found for unit " + characterData);
 
             // Last attempt find the dummy unit synthesis.
             return cardUpgrades.FindLast(u => characterData == u.GetSourceSynthesisUnit());
@@ -227,7 +224,7 @@ namespace Trainworks.Managers
             // it will change them all. Probably not what you want.
             if (BuildersV2.BuilderUtils.IsFromBaseGame(RoomModifierClassType))
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Room Modifier Class Type: " + RoomModifierClassType.FullName + " is a base game Room Modifier. Ignoring.");
+                Trainworks.Log(LogLevel.Warning, "Room Modifier Class Type: " + RoomModifierClassType.FullName + " is a base game Room Modifier. Ignoring.");
                 return;
             }
 

--- a/TrainworksModdingTools/Managers/CustomClassManager.cs
+++ b/TrainworksModdingTools/Managers/CustomClassManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using BepInEx.Logging;
 using HarmonyLib;
@@ -72,7 +73,8 @@ namespace Trainworks.Managers
             var vanillaClan = ProviderManager.SaveManager.GetAllGameData().FindClassData(classID);
             if (vanillaClan == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find clan: " + classID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find clan: " + classID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaClan;
         }

--- a/TrainworksModdingTools/Managers/CustomEnhancerManager.cs
+++ b/TrainworksModdingTools/Managers/CustomEnhancerManager.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx.Logging;
 using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using Trainworks.ConstantsV2;
 using Trainworks.Managers;
@@ -51,7 +52,8 @@ namespace Trainworks.ManagersV2
 
             if (enhancerPool == null)
             {
-                Trainworks.Log(LogLevel.All, "Could not find EnhancerPool wtih id " + enhancerPoolID + " ignoring adding enhancer: " + enhancerData.name + " to this pool.");
+                Trainworks.Log(LogLevel.Error, "Could not find EnhancerPool wtih id " + enhancerPoolID + " ignoring adding enhancer: " + enhancerData.name + " to this pool.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
                 return;
             }
 
@@ -105,7 +107,8 @@ namespace Trainworks.ManagersV2
                 }
             }
 
-            Trainworks.Log(LogLevel.Warning, "Couldn't find enhancer: " + enhancerID + " - This will cause crashes.");
+            Trainworks.Log(LogLevel.Error, "Couldn't find enhancer: " + enhancerID + " - This will cause crashes.");
+            Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
 
             return null;
         }

--- a/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
+++ b/TrainworksModdingTools/Managers/CustomLocalizationManager.cs
@@ -209,7 +209,7 @@ namespace Trainworks.Managers
         {
             if (ReplacementStrings.ContainsKey(keyword))
             {
-                Trainworks.Log("Attempt to add duplicate Replacement String Keyword: " + keyword);
+                Trainworks.Log(LogLevel.Warning, "Attempt to add duplicate Replacement String Keyword: " + keyword);
                 return false;
             }
             ReplacementStringData replacementStringData = new ReplacementStringData();

--- a/TrainworksModdingTools/Managers/CustomMutatorManager.cs
+++ b/TrainworksModdingTools/Managers/CustomMutatorManager.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx.Logging;
+using System;
 using System.Collections.Generic;
 using Trainworks.Managers;
 using Trainworks.Utilities;
@@ -50,7 +51,8 @@ namespace Trainworks.ManagersV2
             var vanillaMutator = ProviderManager.SaveManager.GetAllGameData().FindMutatorData(mutatorID);
             if (vanillaMutator == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find mutator: " + mutatorID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find mutator: " + mutatorID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaMutator;
         }

--- a/TrainworksModdingTools/Managers/CustomRelicManager.cs
+++ b/TrainworksModdingTools/Managers/CustomRelicManager.cs
@@ -59,7 +59,8 @@ namespace Trainworks.Managers
             var vanillaRelic = ProviderManager.SaveManager.GetAllGameData().FindCollectableRelicData(relicID);
             if (vanillaRelic == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find relic: " + relicID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find relic: " + relicID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaRelic;
         }

--- a/TrainworksModdingTools/Managers/CustomScenarioManager.cs
+++ b/TrainworksModdingTools/Managers/CustomScenarioManager.cs
@@ -64,7 +64,8 @@ namespace Trainworks.Managers
             var vanillaScenario = ProviderManager.SaveManager.GetAllGameData().FindScenarioData(id);
             if (vanillaScenario == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find scenario: " + id + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find scenario: " + id + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaScenario;
         }
@@ -104,7 +105,8 @@ namespace Trainworks.Managers
             var vanillaSins = ProviderManager.SaveManager.GetAllGameData().FindEnemySinsData(sinsID);
             if (vanillaSins == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find SinsData: " + sinsID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find SinsData: " + sinsID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaSins;
         }
@@ -147,7 +149,8 @@ namespace Trainworks.Managers
             var vanillaTrial = ProviderManager.SaveManager.GetAllGameData().FindTrialData(trialID);
             if (vanillaTrial == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find TrialData: " + trialID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find TrialData: " + trialID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaTrial;
         }

--- a/TrainworksModdingTools/Managers/CustomUpgradeManager.cs
+++ b/TrainworksModdingTools/Managers/CustomUpgradeManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx.Logging;
+using Steamworks;
 using Trainworks.Managers;
 using Trainworks.Utilities;
 
@@ -26,6 +27,8 @@ namespace Trainworks.ManagersV2
                 }
 
                 upgradeList.Add(upgrade);
+
+                ContentValidator.Validate(upgrade);
             }
             else
             {

--- a/TrainworksModdingTools/Managers/CustomUpgradeManager.cs
+++ b/TrainworksModdingTools/Managers/CustomUpgradeManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using BepInEx.Logging;
 using Trainworks.Managers;
@@ -50,7 +51,8 @@ namespace Trainworks.ManagersV2
             var vanillaUpgrade = ProviderManager.SaveManager.GetAllGameData().FindCardUpgradeData(upgradeID);
             if (vanillaUpgrade == null)
             {
-                Trainworks.Log(LogLevel.Warning, "Couldn't find upgrade: " + upgradeID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Error, "Couldn't find upgrade: " + upgradeID + " - This will cause crashes.");
+                Trainworks.Log(LogLevel.Debug, "Stacktrace: " + Environment.StackTrace);
             }
             return vanillaUpgrade;
         }

--- a/TrainworksModdingTools/Patches/CustomAssetLoadingPatch.cs
+++ b/TrainworksModdingTools/Patches/CustomAssetLoadingPatch.cs
@@ -101,7 +101,7 @@ namespace Trainworks.Patches
                 {
                     if (info.instCount > 0)
                     {
-                        Trainworks.Log(LogLevel.Warning, string.Format("Unloading asset {1} failed.  It has {0} instances in scene.  We expect that soon this instance will be destroyed so that this asset unloads.", info.instCount, assetRef.DebugName));
+                        Trainworks.Log(LogLevel.Error, string.Format("Unloading asset {1} failed.  It has {0} instances in scene.  We expect that soon this instance will be destroyed so that this asset unloads.", info.instCount, assetRef.DebugName));
                         __result = false;
                         return false;
                     }

--- a/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
+++ b/TrainworksModdingTools/Patches/CustomClassSelectScreenCharacterDisplayPatch.cs
@@ -54,7 +54,7 @@ namespace Trainworks.Patches
                 GameObject gameObject = BundleManager.LoadAssetFromBundle(bundleInfo, bundleInfo.ObjectName) as GameObject;
                 if (gameObject == null)
                 {
-                    Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Could not find skeletonData for " + bundleInfo.ObjectName);
+                    Trainworks.Log(LogLevel.Error, "Could not find skeletonData for " + bundleInfo.ObjectName);
                     UpdateCharacterDisplayGameObject(characterState, sprite);
                     return null;
                 }

--- a/TrainworksModdingTools/Patches/CustomTriggerNamePatch.cs
+++ b/TrainworksModdingTools/Patches/CustomTriggerNamePatch.cs
@@ -1,12 +1,11 @@
 ﻿using HarmonyLib;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.RegularExpressions;
-using Trainworks.Enums.MTTriggers;
 
-namespace TrainworksModdingTools.Patches
+namespace Trainworks.Patches
 {
+    // Patch to prevent a rare incorrect localization key being formed for a tooltip.
+    // Fixes Trigger tooltips for CardEffectPlayUnitTrigger and CardEffectReplayTriggers.
     [HarmonyPatch(typeof(TooltipUI), nameof(TooltipUI.InitCardExplicitTooltip))]
     public class CustomTriggerNamePatch
     {

--- a/TrainworksModdingTools/Patches/CustomTriggerNamePatch.cs
+++ b/TrainworksModdingTools/Patches/CustomTriggerNamePatch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Trainworks.Enums.MTTriggers;
+
+namespace TrainworksModdingTools.Patches
+{
+    [HarmonyPatch(typeof(TooltipUI), nameof(TooltipUI.InitCardExplicitTooltip))]
+    public class CustomTriggerNamePatch
+    {
+        private static Regex pattern = new Regex(@"Trigger_(?<triggerid>\d+)_");
+
+        public static void Prefix(ref string titleKey, ref string descriptionKey)
+        {
+            if (titleKey == null || descriptionKey == null) return;
+
+            var match = pattern.Match(titleKey);
+            if (!match.Success) return;
+
+
+            var triggerId = (CharacterTriggerData.Trigger) Int32.Parse(match.Groups["triggerid"].Value);
+            var baseKey = CharacterTriggerData.TriggerToLocalizationExpression[triggerId];
+
+            titleKey = baseKey + "_CardText";
+            descriptionKey = baseKey + "_TooltipText";
+        }
+    }
+}

--- a/TrainworksModdingTools/Utilities/ContentValidator.cs
+++ b/TrainworksModdingTools/Utilities/ContentValidator.cs
@@ -7,16 +7,57 @@ namespace Trainworks.Utilities
 {
     public static class ContentValidator
     {
-        public static void Validate(CardData cardData)
+        private static List<String> SCALING_UNIT_TRAITS = new List<String>()
+        {
+            "CardTraitScalingUpgradeUnitAttack",
+            "CardTraitScalingUpgradeUnitHealth",
+            "CardTraitScalingUpgradeUnitSize",
+            "CardTraitScalingUpgradeUnitStatusEffect",
+        };
+
+        public static void Validate(CardData card)
         {
             // The Starter rarity is unused. Not even the starter cards in game have the rarity set to Starter.
             // This may cause issues if the card is present in a CardPool, since CardPools are filtered when pulling from them
             // A card marked with this rarity will never be chosen. If it is the only card in the pool the game will crash.
-            if (cardData.GetRarity() == CollectableRarity.Starter)
+            if (card.GetRarity() == CollectableRarity.Starter)
             {
-                Trainworks.Log(LogLevel.Warning, "CardData " + cardData.name + " has rarity set to Starter. " +
+                Trainworks.Log(LogLevel.Warning, "CardData " + card.name + " has rarity set to Starter. " +
                     "The Starter rarity is considered an invalid value for CardData and may cause problems if present in CardPools. Consider removing the rarity from this card.");
             }
+            if (card.IsSpawnerCard())
+            {
+                Validate(card, card.GetSpawnCharacterData());
+            }
+        }
+
+        public static void Validate(CharacterData character)
+        {
+        }
+
+        public static void Validate(CardData card, CharacterData character)
+        {
+            foreach (var trait in card.GetTraits())
+            {
+                if (SCALING_UNIT_TRAITS.Contains(trait.GetTraitStateName()))
+                {
+                    Trainworks.Log(LogLevel.Warning, "CardData " + card.name + " spawns a character " + character.name + " and has a CardTrait with a scaling upgrade effect." +
+                        " Consider using " + trait.GetTraitStateName() + "Safely as any upgrades the character applies to itself and others will be scaled which is probably not what you intended.");
+                }
+            }
+        }
+
+        public static void Validate(CardUpgradeData upgrade)
+        {
+            if (upgrade.IsUnitSynthesisUpgrade() && upgrade.GetSourceSynthesisUnit() == null)
+            {
+                Trainworks.Log(LogLevel.Warning, "CardUpgrade " + upgrade.name + " has isUnitSynthesis set, but no SourceSynthesisUnit set.");
+            }
+        }
+
+        public static void Validate(CollectableRelicData relic)
+        {
+
         }
 
     }

--- a/TrainworksModdingTools/Utilities/ContentValidator.cs
+++ b/TrainworksModdingTools/Utilities/ContentValidator.cs
@@ -1,0 +1,23 @@
+﻿using BepInEx.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Trainworks.Utilities
+{
+    public static class ContentValidator
+    {
+        public static void Validate(CardData cardData)
+        {
+            // The Starter rarity is unused. Not even the starter cards in game have the rarity set to Starter.
+            // This may cause issues if the card is present in a CardPool, since CardPools are filtered when pulling from them
+            // A card marked with this rarity will never be chosen. If it is the only card in the pool the game will crash.
+            if (cardData.GetRarity() == CollectableRarity.Starter)
+            {
+                Trainworks.Log(LogLevel.Warning, "CardData " + cardData.name + " has rarity set to Starter. " +
+                    "The Starter rarity is considered an invalid value for CardData and may cause problems if present in CardPools. Consider removing the rarity from this card.");
+            }
+        }
+
+    }
+}

--- a/TrainworksModdingTools/Utilities/GUIDGenerator.cs
+++ b/TrainworksModdingTools/Utilities/GUIDGenerator.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Security.Cryptography;
 using HarmonyLib;
 using System.Reflection;
+using BepInEx.Logging;
 
 namespace Trainworks.Utilities
 {
@@ -18,7 +19,7 @@ namespace Trainworks.Utilities
         {
             if (key == null)
             {
-                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "GUIDGenerator cannot generate determinstic GUID for null key");
+                Trainworks.Log(LogLevel.Error, "GUIDGenerator cannot generate determinstic GUID for null key");
                 return key;
             }
 


### PR DESCRIPTION
1. Fix for a rare trigger localization key issue if CardEffectPlayUnitTrigger or CardEffectReplayTriggers was used.
2. Add ExcludeIfUnitSynthetized To CardUpgradeMaskDataBuilder
3. Revamp logging messages. If an object is not found the logging message is moved to the Error Level. Stacktraces are logged to the Debug Level.